### PR TITLE
docs(agents): add Integration Test phase to org-standard workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,15 @@ fundamentals/      → Step-by-step reference for core operations
 
 ## Development Workflow (cubrid-labs org standard)
 
-All non-trivial work across cubrid-labs repositories MUST follow this 4-phase cycle:
+All non-trivial work across cubrid-labs repositories MUST follow this 5-phase cycle:
 
 1. **Oracle Design Review** — Consult Oracle before implementation to validate architecture, API surface, and approach. Raise concerns early.
 2. **Implementation** — Build the feature/fix with tests. Follow existing codebase patterns.
 3. **Documentation Update** — Update ALL affected docs (README, CHANGELOG, ROADMAP, API docs, SUPPORT_MATRIX, PRD, etc.) in the same PR or as an immediate follow-up. Code without doc updates is incomplete.
-4. **Oracle Post-Implementation Review** — Consult Oracle to review the completed work for correctness, edge cases, and consistency before merging.
+4. **Integration Test against real CUBRID** — Run the feature/fix against a live CUBRID instance via the repo's Docker setup or CI integration matrix. Mock-only validation is INSUFFICIENT. No release may proceed until the relevant integration jobs are green for the target CUBRID/runtime versions.
+5. **Oracle Post-Implementation Review** — Consult Oracle to review the completed work for correctness, edge cases, integration coverage, and consistency before merging.
 
-Skipping any phase requires explicit justification. Trivial changes (typos, single-line fixes) may skip phases 1 and 4.
+Skipping any phase requires explicit justification recorded in the PR description. Trivial changes (typos, single-line fixes, doc-only edits) may skip phases 1, 4, and 5. Phase 4 is NEVER skippable for any change that touches runtime code paths, including changes that "only" add a new module, a new code path, or a new dependency.
 
 ## Validation
 


### PR DESCRIPTION
## Motivation

Two recent releases shipped without real-DB validation. This change makes integration testing a mandatory phase, not a follow-up.

`sqlalchemy-cubrid v1.2.0` and `pycubrid v1.1.0` both shipped to PyPI with new features tested only via mocks — never against a live CUBRID instance. This PR patches that gap in the development process.

## What Changed

- **4-phase → 5-phase** workflow cycle
- **New Phase 4**: Integration Test against real CUBRID — live-DB validation via the repo's Docker setup or CI integration matrix is now mandatory
- **Harder skip language**: Phase 4 is NEVER skippable for any change that touches runtime code paths; trivial/doc-only changes may skip phases 1, 4, and 5; all skips must be recorded in the PR description

## Diff Highlights

```diff
-All non-trivial work across cubrid-labs repositories MUST follow this 4-phase cycle:
+All non-trivial work across cubrid-labs repositories MUST follow this 5-phase cycle:

 1. Oracle Design Review
 2. Implementation
 3. Documentation Update
+4. Integration Test against real CUBRID — Mock-only validation is INSUFFICIENT. No release may proceed until integration jobs are green.
 5. Oracle Post-Implementation Review (was 4)

-Skipping any phase requires explicit justification. Trivial changes (typos, single-line fixes) may skip phases 1 and 4.
+Skipping any phase requires explicit justification recorded in the PR description. Trivial changes (typos, single-line fixes, doc-only edits) may skip phases 1, 4, and 5. Phase 4 is NEVER skippable for any change that touches runtime code paths.
```

## This is the canonical change

This cubrid-cookbook-python PR is the canonical reference. All 11 other cubrid-labs repositories receive the identical change, cross-referencing this PR.