### PR TITLE
ci: add doc-lint job using reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,10 @@ jobs:
         run: ruff check .
       - name: Ruff format check
         run: ruff format --check .
+
+  doc-lint:
+    name: Documentation lint
+    uses: cubrid-lab/.github/.github/workflows/doc-lint.yml@main
+    with:
+      exclude: "node_modules/,typescript/node_modules/,vendor/"
+      fail-on-issue: false  # advisory mode during initial rollout


### PR DESCRIPTION
## Summary

Adds a documentation lint job to CI that calls the reusable workflow at `cubrid-lab/.github/.github/workflows/doc-lint.yml@main`.

Excludes `node_modules/` and `typescript/node_modules/` from all checks.

Advisory mode initially (`fail-on-issue: false`).

## Related
- Reusable workflow: cubrid-lab/.github#17 (merged)

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-opencode)
Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>