### PR TITLE
chore: pin ruff lint selection and clear lint/format debt

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,12 @@ All examples connect to the same CUBRID instance:
 ```python
 # pycubrid (direct)
 import pycubrid
+
 conn = pycubrid.connect(host="localhost", port=33000, database="testdb", user="dba")
 
 # SQLAlchemy
 from sqlalchemy import create_engine
+
 engine = create_engine("cubrid+pycubrid://dba@localhost:33000/testdb")
 ```
 

--- a/fundamentals/lob-handling/expected/06_lob.expected
+++ b/fundamentals/lob-handling/expected/06_lob.expected
@@ -1,11 +1,11 @@
 === CLOB (Character Large Object) ===
   ✓ Inserted 3 documents with CLOB data
-  README          (64 chars): # CUBRID Cookbook
-
-A collection of examples for CUBRID datab...
-  License         (46 chars): Apache License 2.0
-
-Copyright 2026 cubrid-labs
+  README          (66 chars): # CUBRID Cookbook\
+\
+A collection of examples for CUBRID dat...
+  License         (47 chars): Apache License 2.0\
+\
+Copyright 2026 cubrid-lab
   Long Text       (2,800 chars): Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet. Lore...
 
 === BLOB (Binary Large Object) ===

--- a/fundamentals/orm-basics/expected/06_reflection.expected
+++ b/fundamentals/orm-basics/expected/06_reflection.expected
@@ -29,10 +29,10 @@
   cookbook_ref_articles PK: ['id']
 
   Foreign keys on cookbook_ref_articles:
+    ['author_id'] → cookbook_ref_authors.['id']
 
 === Reflect Indexes ===
   Indexes on cookbook_ref_articles:
-    fk_cookbook_ref_articles_author_id  columns=['author_id']
     idx_articles_views              columns=['views']
 
 === Autoload Table ===

--- a/performance/bulk-insert/README.md
+++ b/performance/bulk-insert/README.md
@@ -13,6 +13,7 @@ Inserting 10,000 rows with individual COMMITs takes **~470 seconds** (7.8 minute
 
 ```python
 """Reduce transaction overhead by committing in batches."""
+
 from __future__ import annotations
 
 import pycubrid
@@ -58,6 +59,7 @@ conn.close()
 
 ```python
 """Insert multiple rows in a single call."""
+
 from __future__ import annotations
 
 import pycubrid
@@ -81,6 +83,7 @@ conn.close()
 
 ```python
 """Bulk insert using SQLAlchemy Core (faster than ORM object creation)."""
+
 from __future__ import annotations
 
 from sqlalchemy import create_engine

--- a/performance/bulk-insert/benchmark.py
+++ b/performance/bulk-insert/benchmark.py
@@ -77,10 +77,18 @@ def main() -> None:
 
         # Print results
         print("\n=== Bulk Insert Benchmark ===")
-        print(f"Strategy 1 (per-row COMMIT):     {strategy1_time:.3f}s  {per_row_count} rows  ({strategy1_rows_sec:.0f} rows/sec)")
-        print(f"Strategy 2 (batch COMMIT 500):   {strategy2_time:.3f}s  {num_rows} rows  ({strategy2_rows_sec:.0f} rows/sec)")
-        print(f"Strategy 3 (single COMMIT):      {strategy3_time:.3f}s  {num_rows} rows  ({strategy3_rows_sec:.0f} rows/sec)")
-        print(f"\nKey insight: COMMIT is ~{strategy1_time / per_row_count * 1000:.0f}ms per call — batch your writes!")
+        print(
+            f"Strategy 1 (per-row COMMIT):     {strategy1_time:.3f}s  {per_row_count} rows  ({strategy1_rows_sec:.0f} rows/sec)"
+        )
+        print(
+            f"Strategy 2 (batch COMMIT 500):   {strategy2_time:.3f}s  {num_rows} rows  ({strategy2_rows_sec:.0f} rows/sec)"
+        )
+        print(
+            f"Strategy 3 (single COMMIT):      {strategy3_time:.3f}s  {num_rows} rows  ({strategy3_rows_sec:.0f} rows/sec)"
+        )
+        print(
+            f"\nKey insight: COMMIT is ~{strategy1_time / per_row_count * 1000:.0f}ms per call — batch your writes!"
+        )
         print()
 
     finally:

--- a/performance/connection-pooling/README.md
+++ b/performance/connection-pooling/README.md
@@ -15,16 +15,17 @@ In a web application creating a new connection per request:
 
 ```python
 """Use SQLAlchemy's built-in connection pool."""
+
 from __future__ import annotations
 
 from sqlalchemy import create_engine, text
 
 engine = create_engine(
     "cubrid+pycubrid://dba@localhost:33000/testdb",
-    pool_size=5,         # Number of connections to keep in the pool
-    max_overflow=10,     # Extra connections allowed beyond pool_size
-    pool_timeout=30,     # Max seconds to wait for a connection
-    pool_recycle=3600,   # Recreate connections after 1 hour (handles CUBRID idle timeout)
+    pool_size=5,  # Number of connections to keep in the pool
+    max_overflow=10,  # Extra connections allowed beyond pool_size
+    pool_timeout=30,  # Max seconds to wait for a connection
+    pool_recycle=3600,  # Recreate connections after 1 hour (handles CUBRID idle timeout)
     pool_pre_ping=True,  # Validate connections before use
 )
 
@@ -41,6 +42,7 @@ with engine.connect() as conn:
 
 ```python
 """Per-request session management in FastAPI."""
+
 from __future__ import annotations
 
 from collections.abc import Generator
@@ -93,7 +95,7 @@ Set `pool_recycle` shorter than the server timeout to avoid stale connections.
 # Set pool_recycle well below that (safety margin)
 engine = create_engine(
     "cubrid+pycubrid://dba@localhost:33000/testdb",
-    pool_recycle=3600,   # 1 hour — 1/6 of server timeout
+    pool_recycle=3600,  # 1 hour — 1/6 of server timeout
     pool_pre_ping=True,  # Detect broken connections before use
 )
 ```

--- a/performance/connection-pooling/benchmark.py
+++ b/performance/connection-pooling/benchmark.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from sqlalchemy import create_engine, text
-from sqlalchemy.pool import NullPool, QueuePool
+from sqlalchemy.pool import NullPool
 
 
 def main() -> None:

--- a/performance/fetch-optimization/README.md
+++ b/performance/fetch-optimization/README.md
@@ -49,13 +49,14 @@ rows = cursor.fetchall()
 # Don't fetch 100K rows at once — paginate on the server
 PAGE_SIZE = 1000
 
+
 def fetch_page(cursor, offset: int, limit: int) -> list:
     cursor.execute(
-        "SELECT order_id, total_amt FROM cookbook_orders "
-        "ORDER BY order_id LIMIT ?, ?",
+        "SELECT order_id, total_amt FROM cookbook_orders ORDER BY order_id LIMIT ?, ?",
         (offset, limit),
     )
     return cursor.fetchall()
+
 
 # Usage
 page = fetch_page(cursor, offset=0, limit=PAGE_SIZE)

--- a/pitfalls/README.md
+++ b/pitfalls/README.md
@@ -33,6 +33,7 @@ engine = create_engine(
 )
 SessionLocal = sessionmaker(bind=engine)
 
+
 @app.get("/items")
 def list_items():
     with SessionLocal() as session:
@@ -158,7 +159,7 @@ session.execute(stmt)
 # ❌ Anti-pattern — sync DB call in async handler blocks the event loop
 @app.get("/items")
 async def list_items():
-    conn = pycubrid.connect(...)    # Blocks event loop
+    conn = pycubrid.connect(...)  # Blocks event loop
     cursor = conn.cursor()
     cursor.execute("SELECT * FROM cookbook_items")  # Blocks event loop
     rows = cursor.fetchall()
@@ -175,11 +176,13 @@ async def list_items():
 def list_items(db: Session = Depends(get_db)):
     return db.execute(text("SELECT * FROM cookbook_items")).all()
 
+
 # ✅ Option B — explicit thread pool for async handler
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 executor = ThreadPoolExecutor(max_workers=5)
+
 
 @app.get("/items")
 async def list_items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+
+[tool.ruff.lint]
+# Pin the rule set explicitly instead of inheriting ruff's implicit defaults.
+# Ruff expanded its default selection in 0.16 (59 -> 413 rules against this
+# config), which turns every routine ruff bump into a CI-breaking change
+# unrelated to our own code. These four groups are exactly what ruff selected
+# by default through 0.15.x.
+select = ["E4", "E7", "E9", "F"]
+
+[tool.ruff.lint.per-file-ignores]
+# Test suites bootstrap sys.path before importing the module under test,
+# so their imports are intentionally not at the top of the file.
+"**/tests/*.py" = ["E402"]
+# Flask template app.py files intentionally place demo imports mid-file to
+# illustrate patterns; moving them would change the teaching structure.
+"templates/flask/**/app.py" = ["E402"]

--- a/templates/api-service-fastapi/app/models.py
+++ b/templates/api-service-fastapi/app/models.py
@@ -22,6 +22,7 @@ class CookbookCategory(Base):
         # passive_deletes removed — CUBRID FK cascade support varies (issue #33).
     )
 
+
 class CookbookItem(Base):
     __tablename__ = "cookbook_items"
 

--- a/templates/api-service-fastapi/recipes/03-catalog-sync/models.py
+++ b/templates/api-service-fastapi/recipes/03-catalog-sync/models.py
@@ -1,14 +1,15 @@
 # pyright: reportImplicitRelativeImport=false, reportUnusedParameter=false
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import DateTime, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
 
 from database import Base
 
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
 
 class CatalogItem(Base):
     __tablename__: str = "cookbook_catalog_items"
@@ -20,6 +21,7 @@ class CatalogItem(Base):
     available: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     source_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     last_synced_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=utc_now)
+
 
 class SyncRun(Base):
     __tablename__: str = "cookbook_sync_runs"

--- a/templates/api-service-fastapi/recipes/03-catalog-sync/schemas.py
+++ b/templates/api-service-fastapi/recipes/03-catalog-sync/schemas.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class CatalogItemSync(BaseModel):
@@ -11,9 +11,11 @@ class CatalogItemSync(BaseModel):
     price: int = Field(gt=0)
     available: int = Field(ge=0, le=1)
 
+
 class CatalogSyncRequest(BaseModel):
     source: str = Field(min_length=1, max_length=100)
     items: list[CatalogItemSync] = Field(min_length=1)
+
 
 class CatalogItemResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -25,6 +27,7 @@ class CatalogItemResponse(BaseModel):
     available: int
     source_version: int
     last_synced_at: datetime
+
 
 class SyncRunResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)

--- a/templates/api-service-fastapi/recipes/03-catalog-sync/tests/test_main.py
+++ b/templates/api-service-fastapi/recipes/03-catalog-sync/tests/test_main.py
@@ -46,7 +46,6 @@ async def client(db_session: Session):
 from typing import cast
 
 
-
 def build_items(price_offset: int = 0) -> list[dict[str, object]]:
     return [
         {

--- a/templates/api-service-fastapi/recipes/04-audit-trail/models.py
+++ b/templates/api-service-fastapi/recipes/04-audit-trail/models.py
@@ -10,6 +10,7 @@ from database import Base
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
+
 class UserProfile(Base):
     __tablename__: str = "cookbook_user_profiles"
 
@@ -29,6 +30,7 @@ class UserProfile(Base):
         back_populates="profile",
         cascade="all, delete-orphan",
     )
+
 
 class ProfileEvent(Base):
     __tablename__: str = "cookbook_profile_events"

--- a/templates/api-service-fastapi/recipes/04-audit-trail/schemas.py
+++ b/templates/api-service-fastapi/recipes/04-audit-trail/schemas.py
@@ -10,11 +10,13 @@ class ProfileCreate(BaseModel):
     display_name: str = Field(min_length=1, max_length=255)
     bio: str | None = None
 
+
 class ProfileUpdate(BaseModel):
     expected_version: int = Field(ge=1)
     email: EmailStr | None = None
     display_name: str | None = Field(default=None, min_length=1, max_length=255)
     bio: str | None = None
+
 
 class ProfileResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -26,6 +28,7 @@ class ProfileResponse(BaseModel):
     version: int
     created_at: datetime
     updated_at: datetime
+
 
 class ProfileEventResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)

--- a/templates/api-service-fastapi/recipes/04-audit-trail/tests/test_main.py
+++ b/templates/api-service-fastapi/recipes/04-audit-trail/tests/test_main.py
@@ -47,7 +47,6 @@ import json
 from typing import cast
 
 
-
 @pytest.mark.asyncio
 async def test_create_profile(client: AsyncClient) -> None:
     payload = {

--- a/templates/api-service-fastapi/recipes/05-multi-tenant-search/models.py
+++ b/templates/api-service-fastapi/recipes/05-multi-tenant-search/models.py
@@ -1,14 +1,15 @@
 # pyright: reportImplicitRelativeImport=false, reportUnusedParameter=false
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
 
 from database import Base
 
 
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
+
 
 class Tenant(Base):
     __tablename__: str = "cookbook_tenants"
@@ -17,6 +18,7 @@ class Tenant(Base):
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     slug: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=utc_now)
+
 
 class Contact(Base):
     __tablename__: str = "cookbook_contacts"

--- a/templates/api-service-fastapi/recipes/05-multi-tenant-search/schemas.py
+++ b/templates/api-service-fastapi/recipes/05-multi-tenant-search/schemas.py
@@ -9,6 +9,7 @@ class TenantCreate(BaseModel):
     name: str = Field(min_length=1, max_length=120)
     slug: str = Field(min_length=1, max_length=50)
 
+
 class TenantResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
 
@@ -17,6 +18,7 @@ class TenantResponse(BaseModel):
     slug: str
     created_at: datetime
 
+
 class ContactCreate(BaseModel):
     first_name: str = Field(min_length=1, max_length=100)
     last_name: str = Field(min_length=1, max_length=100)
@@ -24,12 +26,14 @@ class ContactCreate(BaseModel):
     city: str | None = Field(default=None, max_length=100)
     status: str = Field(default="active", min_length=1, max_length=20)
 
+
 class ContactUpdate(BaseModel):
     first_name: str | None = Field(default=None, min_length=1, max_length=100)
     last_name: str | None = Field(default=None, min_length=1, max_length=100)
     email: EmailStr | None = None
     city: str | None = Field(default=None, max_length=100)
     status: str | None = Field(default=None, min_length=1, max_length=20)
+
 
 class ContactResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -42,6 +46,7 @@ class ContactResponse(BaseModel):
     city: str | None
     status: str
     created_at: datetime
+
 
 class ContactCursorList(BaseModel):
     items: list[ContactResponse]

--- a/templates/api-service-fastapi/recipes/05-multi-tenant-search/tests/test_main.py
+++ b/templates/api-service-fastapi/recipes/05-multi-tenant-search/tests/test_main.py
@@ -46,7 +46,6 @@ async def client(db_session: Session):
 from typing import cast
 
 
-
 async def create_tenant(client: AsyncClient, name: str, slug: str) -> dict[str, object]:
     response = await client.post("/tenants", json={"name": name, "slug": slug})
     assert response.status_code == 201

--- a/templates/api-service-fastapi/recipes/06-price-books/models.py
+++ b/templates/api-service-fastapi/recipes/06-price-books/models.py
@@ -1,7 +1,7 @@
 # pyright: reportImplicitRelativeImport=false, reportUnusedParameter=false
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from database import Base
@@ -10,6 +10,7 @@ from database import Base
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
+
 class PriceProduct(Base):
     __tablename__: str = "cookbook_price_products"
 
@@ -17,6 +18,7 @@ class PriceProduct(Base):
     sku: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     active: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+
 
 class PriceBookEntry(Base):
     __tablename__: str = "cookbook_price_book_entries"

--- a/templates/api-service-fastapi/recipes/06-price-books/schemas.py
+++ b/templates/api-service-fastapi/recipes/06-price-books/schemas.py
@@ -2,12 +2,13 @@
 from datetime import datetime
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class PriceProductCreate(BaseModel):
     sku: str = Field(min_length=1, max_length=100)
     name: str = Field(min_length=1, max_length=255)
+
 
 class PriceProductResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -17,6 +18,7 @@ class PriceProductResponse(BaseModel):
     name: str
     active: int
 
+
 class PriceEntryCreate(BaseModel):
     product_id: int
     channel: str = Field(min_length=1, max_length=30)
@@ -24,6 +26,7 @@ class PriceEntryCreate(BaseModel):
     amount_cents: int = Field(gt=0)
     starts_at: datetime
     ends_at: datetime | None = None
+
 
 class PriceEntryResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -36,6 +39,7 @@ class PriceEntryResponse(BaseModel):
     starts_at: datetime
     ends_at: datetime | None
     version: int
+
 
 class SupersedeRequest(BaseModel):
     new_amount_cents: int = Field(gt=0)

--- a/templates/api-service-fastapi/recipes/07-document-publishing/models.py
+++ b/templates/api-service-fastapi/recipes/07-document-publishing/models.py
@@ -10,6 +10,7 @@ from database import Base
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
+
 class Document(Base):
     __tablename__: str = "cookbook_documents"
 
@@ -27,6 +28,7 @@ class Document(Base):
         onupdate=utc_now,
     )
     revisions: Mapped[list["DocumentRevision"]] = relationship(back_populates="document")
+
 
 class DocumentRevision(Base):
     __tablename__: str = "cookbook_document_revisions"

--- a/templates/api-service-fastapi/recipes/07-document-publishing/schemas.py
+++ b/templates/api-service-fastapi/recipes/07-document-publishing/schemas.py
@@ -2,7 +2,7 @@
 from datetime import datetime
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class DocumentCreate(BaseModel):
@@ -11,10 +11,12 @@ class DocumentCreate(BaseModel):
     body: str = Field(min_length=1)
     created_by: str = Field(min_length=1, max_length=100)
 
+
 class DraftCreate(BaseModel):
     title: str = Field(min_length=1, max_length=255)
     body: str = Field(min_length=1)
     created_by: str = Field(min_length=1, max_length=100)
+
 
 class DocumentResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -28,6 +30,7 @@ class DocumentResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
+
 class RevisionResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
 
@@ -39,6 +42,7 @@ class RevisionResponse(BaseModel):
     source_revision_id: int | None
     created_by: str
     created_at: datetime
+
 
 class DocumentDetailResponse(BaseModel):
     document: DocumentResponse

--- a/templates/api-service-fastapi/recipes/07-document-publishing/tests/test_main.py
+++ b/templates/api-service-fastapi/recipes/07-document-publishing/tests/test_main.py
@@ -46,7 +46,6 @@ async def client(db_session: Session):
 from typing import cast
 
 
-
 @pytest.mark.asyncio
 async def test_create_document_with_first_revision(client: AsyncClient) -> None:
     response = await client.post(

--- a/templates/api-service-fastapi/recipes/08-webhook-inbox/models.py
+++ b/templates/api-service-fastapi/recipes/08-webhook-inbox/models.py
@@ -10,6 +10,7 @@ from database import Base
 def utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
+
 class Shipment(Base):
     __tablename__: str = "cookbook_shipments"
 
@@ -18,6 +19,7 @@ class Shipment(Base):
     carrier: Mapped[str] = mapped_column(String(50), nullable=False)
     current_status: Mapped[str] = mapped_column(String(30), nullable=False, default="unknown")
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
 
 class WebhookEvent(Base):
     __tablename__: str = "cookbook_webhook_events"
@@ -43,6 +45,7 @@ class WebhookEvent(Base):
     received_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=utc_now)
     processed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     attempts_list: Mapped[list["WebhookAttempt"]] = relationship(back_populates="event")
+
 
 class WebhookAttempt(Base):
     __tablename__: str = "cookbook_webhook_attempts"

--- a/templates/api-service-fastapi/recipes/08-webhook-inbox/schemas.py
+++ b/templates/api-service-fastapi/recipes/08-webhook-inbox/schemas.py
@@ -2,12 +2,13 @@
 from datetime import datetime
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ShipmentCreate(BaseModel):
     external_ref: str = Field(min_length=1, max_length=100)
     carrier: str = Field(min_length=1, max_length=50)
+
 
 class ShipmentResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -18,12 +19,14 @@ class ShipmentResponse(BaseModel):
     current_status: str
     delivered_at: datetime | None
 
+
 class WebhookIngest(BaseModel):
     provider: str = Field(min_length=1, max_length=50)
     external_event_id: str = Field(min_length=1, max_length=200)
     event_type: str = Field(min_length=1, max_length=50)
     payload: str
     shipment_external_ref: str | None = Field(default=None, min_length=1, max_length=100)
+
 
 class WebhookAttemptResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -35,6 +38,7 @@ class WebhookAttemptResponse(BaseModel):
     finished_at: datetime | None
     outcome: str
     error_message: str | None
+
 
 class WebhookEventResponse(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(from_attributes=True)
@@ -53,9 +57,11 @@ class WebhookEventResponse(BaseModel):
     processed_at: datetime | None
     attempts_list: list[WebhookAttemptResponse] = Field(default_factory=list)
 
+
 class ProcessRequest(BaseModel):
     processor_token: str = Field(min_length=1, max_length=100)
     max_events: int = Field(default=5, ge=1)
+
 
 class ProcessResult(BaseModel):
     processed: int

--- a/templates/api-service-fastapi/recipes/08-webhook-inbox/tests/test_main.py
+++ b/templates/api-service-fastapi/recipes/08-webhook-inbox/tests/test_main.py
@@ -48,8 +48,6 @@ from models import Shipment
 from typing import cast
 
 
-
-
 @pytest.mark.asyncio
 async def test_ingest_webhook_creates_event(client: AsyncClient) -> None:
     shipment_response = await client.post(

--- a/templates/api-service-fastapi/recipes/09-saga/main.py
+++ b/templates/api-service-fastapi/recipes/09-saga/main.py
@@ -4,10 +4,8 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 try:
-    from .database import Base, engine
     from .routes import router
 except ImportError:
-    from database import Base, engine
     from routes import router
 
 

--- a/templates/api-service-fastapi/recipes/10-cqrs-event-sourcing/tests/test_main.py
+++ b/templates/api-service-fastapi/recipes/10-cqrs-event-sourcing/tests/test_main.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import threading
 from pathlib import Path
 from typing import Generator
 

--- a/templates/api-service-fastapi/recipes/12-reservation-scheduling/schemas.py
+++ b/templates/api-service-fastapi/recipes/12-reservation-scheduling/schemas.py
@@ -37,12 +37,14 @@ class ReservationCreate(BaseModel):
             if value.tzinfo is not None:
                 # Convert to UTC then strip tzinfo
                 from datetime import timezone
+
                 value = value.astimezone(timezone.utc).replace(tzinfo=None)
             return value
         try:
             parsed = datetime.fromisoformat(value)
             if parsed.tzinfo is not None:
                 from datetime import timezone
+
                 parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
             return parsed
         except ValueError as exc:
@@ -74,12 +76,14 @@ class ReservationWindowQuery(BaseModel):
         if isinstance(value, datetime):
             if value.tzinfo is not None:
                 from datetime import timezone
+
                 value = value.astimezone(timezone.utc).replace(tzinfo=None)
             return value
         try:
             parsed = datetime.fromisoformat(value)
             if parsed.tzinfo is not None:
                 from datetime import timezone
+
                 parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
             return parsed
         except ValueError as exc:
@@ -97,12 +101,14 @@ class WaitlistCreate(BaseModel):
         if isinstance(value, datetime):
             if value.tzinfo is not None:
                 from datetime import timezone
+
                 value = value.astimezone(timezone.utc).replace(tzinfo=None)
             return value
         try:
             parsed = datetime.fromisoformat(value)
             if parsed.tzinfo is not None:
                 from datetime import timezone
+
                 parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
             return parsed
         except ValueError as exc:

--- a/templates/dashboard/01_table_viewer.py
+++ b/templates/dashboard/01_table_viewer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import time
 from datetime import date, timedelta
 
 import pandas as pd

--- a/templates/django/app/views.py
+++ b/templates/django/app/views.py
@@ -16,6 +16,7 @@ def _ensure_tables_initialized() -> None:
         create_tables()
         _tables_initialized = True
 
+
 def health_view(_request: HttpRequest) -> JsonResponse:
     _ensure_tables_initialized()
     session = get_session()

--- a/templates/flask/02-categories/app.py
+++ b/templates/flask/02-categories/app.py
@@ -18,20 +18,24 @@ Category = _models.Category
 
 bp = Blueprint("categories", __name__, url_prefix="/api/categories")
 
+
 def _category_or_404(category_id: int) -> Category:
     category = db.session.get(Category, category_id)
     if category is None:
         raise LookupError("Category not found.")
     return category
 
+
 def _is_include_deleted_enabled() -> bool:
     return request.args.get("include_deleted") == "1"
+
 
 def _json_payload() -> Mapping[str, object]:
     payload_value = request.get_json(silent=True)
     if isinstance(payload_value, dict):
         return cast(dict[str, object], payload_value)
     return {}
+
 
 @bp.get("")
 def list_categories():
@@ -40,6 +44,7 @@ def list_categories():
         stmt = stmt.where(Category.is_deleted == 0)
     categories = db.session.execute(stmt).scalars().all()
     return jsonify([category.to_dict() for category in categories])
+
 
 @bp.post("")
 def create_category():
@@ -68,6 +73,7 @@ def create_category():
     db.session.commit()
     return jsonify(category.to_dict()), 201
 
+
 @bp.get("/<int:category_id>")
 def get_category(category_id: int):
     try:
@@ -80,6 +86,7 @@ def get_category(category_id: int):
     articles = [article.to_dict() for article in category.articles if article.is_deleted == 0]
     return jsonify({**category.to_dict(), "children": children, "articles": articles})
 
+
 @bp.delete("/<int:category_id>")
 def soft_delete_category(category_id: int):
     try:
@@ -88,12 +95,17 @@ def soft_delete_category(category_id: int):
         return jsonify({"error": "Category not found."}), 404
     active_children = [child for child in category.children if child.is_deleted == 0]
     if active_children:
-        return jsonify({"error": "Cannot delete category with active children. Delete or reassign children first."}), 409
+        return jsonify(
+            {
+                "error": "Cannot delete category with active children. Delete or reassign children first."
+            }
+        ), 409
     category.is_deleted = 1
     for article in category.articles:
         article.is_deleted = 1
     db.session.commit()
     return jsonify(category.to_dict())
+
 
 @bp.post("/<int:category_id>/restore")
 def restore_category(category_id: int):
@@ -106,6 +118,7 @@ def restore_category(category_id: int):
         article.is_deleted = 0
     db.session.commit()
     return jsonify(category.to_dict())
+
 
 @bp.post("/<int:category_id>/articles")
 def create_article(category_id: int):
@@ -125,13 +138,23 @@ def create_article(category_id: int):
     db.session.commit()
     return jsonify(article.to_dict()), 201
 
+
 @bp.get("/<int:category_id>/articles")
 def list_articles(category_id: int):
     category = db.session.get(Category, category_id)
     if category is None or category.is_deleted == 1:
         return jsonify({"error": "Category not found."}), 404
-    articles = db.session.execute(select(Article).where(Article.category_id == category_id, Article.is_deleted == 0).order_by(Article.id.asc())).scalars().all()
+    articles = (
+        db.session.execute(
+            select(Article)
+            .where(Article.category_id == category_id, Article.is_deleted == 0)
+            .order_by(Article.id.asc())
+        )
+        .scalars()
+        .all()
+    )
     return jsonify([article.to_dict() for article in articles])
+
 
 @bp.delete("/<int:category_id>/articles/<int:article_id>")
 def soft_delete_article(category_id: int, article_id: int):
@@ -145,9 +168,12 @@ def soft_delete_article(category_id: int, article_id: int):
     db.session.commit()
     return jsonify(article.to_dict())
 
+
 def create_app(config=None):
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb"
+    )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     if config:
         app.config.update(config)

--- a/templates/flask/02-categories/models.py
+++ b/templates/flask/02-categories/models.py
@@ -16,11 +16,15 @@ class Category(db.Model):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(120), nullable=False)
-    parent_id: Mapped[int | None] = mapped_column(Integer, ForeignKey("cookbook_categories.id"), nullable=True)
+    parent_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("cookbook_categories.id"), nullable=True
+    )
     is_deleted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
 
-    parent: Mapped["Category | None"] = relationship("Category", remote_side=[id], back_populates="children")
+    parent: Mapped["Category | None"] = relationship(
+        "Category", remote_side=[id], back_populates="children"
+    )
     children: Mapped[list["Category"]] = relationship("Category", back_populates="parent")
     articles: Mapped[list["Article"]] = relationship(back_populates="category")
 
@@ -40,7 +44,9 @@ class Article(db.Model):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     body: Mapped[str | None] = mapped_column(Text, nullable=True)
-    category_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_categories.id"), nullable=False)
+    category_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_categories.id"), nullable=False
+    )
     is_deleted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
 

--- a/templates/flask/03-inventory-ledger/app.py
+++ b/templates/flask/03-inventory-ledger/app.py
@@ -299,9 +299,12 @@ def list_stock_item_movements(item_id: int):
 import os
 from flask import Flask
 
+
 def create_app(config=None):
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb"
+    )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     if config:
         app.config.update(config)

--- a/templates/flask/03-inventory-ledger/models.py
+++ b/templates/flask/03-inventory-ledger/models.py
@@ -21,7 +21,12 @@ class Warehouse(db.Model):
     stock_items: Mapped[list["StockItem"]] = relationship(back_populates="warehouse")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "code": self.code, "name": self.name, "created_at": self.created_at.isoformat()}
+        return {
+            "id": self.id,
+            "code": self.code,
+            "name": self.name,
+            "created_at": self.created_at.isoformat(),
+        }
 
 
 class StockItem(db.Model):
@@ -29,7 +34,9 @@ class StockItem(db.Model):
     __table_args__ = (UniqueConstraint("warehouse_id", "sku", name="uq_stock_item_warehouse_sku"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    warehouse_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_warehouses.id"), nullable=False)
+    warehouse_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_warehouses.id"), nullable=False
+    )
     sku: Mapped[str] = mapped_column(String(100), nullable=False)
     product_name: Mapped[str] = mapped_column(String(255), nullable=False)
     on_hand_qty: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
@@ -38,14 +45,22 @@ class StockItem(db.Model):
     movements: Mapped[list["StockMovement"]] = relationship(back_populates="stock_item")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "warehouse_id": self.warehouse_id, "sku": self.sku, "product_name": self.product_name, "on_hand_qty": self.on_hand_qty}
+        return {
+            "id": self.id,
+            "warehouse_id": self.warehouse_id,
+            "sku": self.sku,
+            "product_name": self.product_name,
+            "on_hand_qty": self.on_hand_qty,
+        }
 
 
 class StockMovement(db.Model):
     __tablename__ = "cookbook_stock_movements"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    stock_item_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_stock_items.id"), nullable=False)
+    stock_item_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_stock_items.id"), nullable=False
+    )
     movement_type: Mapped[str] = mapped_column(String(20), nullable=False)
     qty_delta: Mapped[int] = mapped_column(Integer, nullable=False)
     reference: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -54,4 +69,12 @@ class StockMovement(db.Model):
     stock_item: Mapped["StockItem"] = relationship(back_populates="movements")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "stock_item_id": self.stock_item_id, "movement_type": self.movement_type, "qty_delta": self.qty_delta, "reference": self.reference, "note": self.note, "created_at": self.created_at.isoformat()}
+        return {
+            "id": self.id,
+            "stock_item_id": self.stock_item_id,
+            "movement_type": self.movement_type,
+            "qty_delta": self.qty_delta,
+            "reference": self.reference,
+            "note": self.note,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/templates/flask/04-purchase-orders/app.py
+++ b/templates/flask/04-purchase-orders/app.py
@@ -177,7 +177,9 @@ def submit_purchase_order(order_id: int):
     result = db.session.execute(
         update(PurchaseOrder)
         .where(PurchaseOrder.id == order_id, PurchaseOrder.version == order.version)
-        .values(status="submitted", submitted_at=datetime.now(timezone.utc), version=order.version + 1)
+        .values(
+            status="submitted", submitted_at=datetime.now(timezone.utc), version=order.version + 1
+        )
     )
     if cast(CursorResult[object], result).rowcount == 0:
         return jsonify({"error": "Concurrent modification detected."}), 409
@@ -200,7 +202,9 @@ def approve_purchase_order(order_id: int):
     result = db.session.execute(
         update(PurchaseOrder)
         .where(PurchaseOrder.id == order_id, PurchaseOrder.version == order.version)
-        .values(status="approved", approved_at=datetime.now(timezone.utc), version=order.version + 1)
+        .values(
+            status="approved", approved_at=datetime.now(timezone.utc), version=order.version + 1
+        )
     )
     if cast(CursorResult[object], result).rowcount == 0:
         return jsonify({"error": "Concurrent modification detected."}), 409

--- a/templates/flask/04-purchase-orders/models.py
+++ b/templates/flask/04-purchase-orders/models.py
@@ -21,14 +21,21 @@ class Supplier(db.Model):
     orders: Mapped[list["PurchaseOrder"]] = relationship(back_populates="supplier")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "name": self.name, "code": self.code, "created_at": self.created_at.isoformat()}
+        return {
+            "id": self.id,
+            "name": self.name,
+            "code": self.code,
+            "created_at": self.created_at.isoformat(),
+        }
 
 
 class PurchaseOrder(db.Model):
     __tablename__ = "cookbook_purchase_orders"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    supplier_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_suppliers.id"), nullable=False)
+    supplier_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_suppliers.id"), nullable=False
+    )
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="draft")
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     submitted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
@@ -37,7 +44,9 @@ class PurchaseOrder(db.Model):
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     supplier: Mapped["Supplier"] = relationship(back_populates="orders")
-    lines: Mapped[list["PurchaseOrderLine"]] = relationship(back_populates="order", cascade="all, delete-orphan")
+    lines: Mapped[list["PurchaseOrderLine"]] = relationship(
+        back_populates="order", cascade="all, delete-orphan"
+    )
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -57,7 +66,9 @@ class PurchaseOrderLine(db.Model):
     __tablename__ = "cookbook_purchase_order_lines"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    order_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_purchase_orders.id"), nullable=False)
+    order_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_purchase_orders.id"), nullable=False
+    )
     sku: Mapped[str] = mapped_column(String(100), nullable=False)
     description: Mapped[str] = mapped_column(String(255), nullable=False)
     quantity: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -66,4 +77,12 @@ class PurchaseOrderLine(db.Model):
     order: Mapped["PurchaseOrder"] = relationship(back_populates="lines")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "order_id": self.order_id, "sku": self.sku, "description": self.description, "quantity": self.quantity, "unit_cost": self.unit_cost, "received_qty": self.received_qty}
+        return {
+            "id": self.id,
+            "order_id": self.order_id,
+            "sku": self.sku,
+            "description": self.description,
+            "quantity": self.quantity,
+            "unit_cost": self.unit_cost,
+            "received_qty": self.received_qty,
+        }

--- a/templates/flask/04-purchase-orders/tests/test_app.py
+++ b/templates/flask/04-purchase-orders/tests/test_app.py
@@ -19,7 +19,13 @@ create_app = importlib.import_module("app").create_app
 
 @pytest.fixture
 def app(tmp_path: Path):
-    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}", "SQLALCHEMY_TRACK_MODIFICATIONS": False})
+    return create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+    )
 
 
 @pytest.fixture
@@ -27,6 +33,7 @@ def httpx_client(app):
     transport = httpx.WSGITransport(app=app)
     with httpx.Client(transport=transport, base_url="http://testserver") as client:
         yield client
+
 
 class SupplierPayload(TypedDict):
     id: int

--- a/templates/flask/05-batch-operations/app.py
+++ b/templates/flask/05-batch-operations/app.py
@@ -200,6 +200,7 @@ def submit_price_update_job():
         }
     ), 201
 
+
 @batch_bp.get("/jobs")
 def list_batch_jobs():
     jobs = db.session.execute(select(BatchJob).order_by(BatchJob.id.desc())).scalars().all()
@@ -233,9 +234,12 @@ def get_batch_job(job_id: int):
 import os
 from flask import Flask
 
+
 def create_app(config=None):
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb"
+    )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     if config:
         app.config.update(config)

--- a/templates/flask/05-batch-operations/models.py
+++ b/templates/flask/05-batch-operations/models.py
@@ -22,7 +22,14 @@ class BatchProduct(db.Model):
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "sku": self.sku, "name": self.name, "price": self.price, "is_active": self.is_active, "created_at": self.created_at.isoformat()}
+        return {
+            "id": self.id,
+            "sku": self.sku,
+            "name": self.name,
+            "price": self.price,
+            "is_active": self.is_active,
+            "created_at": self.created_at.isoformat(),
+        }
 
 
 class BatchJob(db.Model):
@@ -39,14 +46,25 @@ class BatchJob(db.Model):
     rows: Mapped[list["BatchJobRow"]] = relationship(back_populates="job")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "job_type": self.job_type, "status": self.status, "total_rows": self.total_rows, "success_cnt": self.success_cnt, "failed_cnt": self.failed_cnt, "created_at": self.created_at.isoformat(), "finished_at": self.finished_at.isoformat() if self.finished_at else None}
+        return {
+            "id": self.id,
+            "job_type": self.job_type,
+            "status": self.status,
+            "total_rows": self.total_rows,
+            "success_cnt": self.success_cnt,
+            "failed_cnt": self.failed_cnt,
+            "created_at": self.created_at.isoformat(),
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+        }
 
 
 class BatchJobRow(db.Model):
     __tablename__ = "cookbook_batch_job_rows"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    job_id: Mapped[int] = mapped_column(Integer, db.ForeignKey("cookbook_batch_jobs.id"), nullable=False)
+    job_id: Mapped[int] = mapped_column(
+        Integer, db.ForeignKey("cookbook_batch_jobs.id"), nullable=False
+    )
     row_index: Mapped[int] = mapped_column(Integer, nullable=False)
     sku: Mapped[str] = mapped_column(String(100), nullable=False)
     payload: Mapped[str] = mapped_column(Text, nullable=False)
@@ -55,4 +73,12 @@ class BatchJobRow(db.Model):
     job: Mapped["BatchJob"] = relationship(back_populates="rows")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "job_id": self.job_id, "row_index": self.row_index, "sku": self.sku, "payload": self.payload, "status": self.status, "error_message": self.error_message}
+        return {
+            "id": self.id,
+            "job_id": self.job_id,
+            "row_index": self.row_index,
+            "sku": self.sku,
+            "payload": self.payload,
+            "status": self.status,
+            "error_message": self.error_message,
+        }

--- a/templates/flask/05-batch-operations/tests/test_app.py
+++ b/templates/flask/05-batch-operations/tests/test_app.py
@@ -24,7 +24,13 @@ BatchProduct = _models.BatchProduct
 
 @pytest.fixture
 def app(tmp_path: Path):
-    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}", "SQLALCHEMY_TRACK_MODIFICATIONS": False})
+    return create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+    )
 
 
 @pytest.fixture
@@ -32,6 +38,7 @@ def httpx_client(app):
     transport = httpx.WSGITransport(app=app)
     with httpx.Client(transport=transport, base_url="http://testserver") as client:
         yield client
+
 
 class BatchProductPayload(TypedDict):
     id: int

--- a/templates/flask/06-case-triage/app.py
+++ b/templates/flask/06-case-triage/app.py
@@ -320,9 +320,12 @@ def add_case_note(case_id: int):
 import os
 from flask import Flask
 
+
 def create_app(config=None):
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb"
+    )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     if config:
         app.config.update(config)

--- a/templates/flask/06-case-triage/models.py
+++ b/templates/flask/06-case-triage/models.py
@@ -25,7 +25,9 @@ class ReviewCase(db.Model):
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
-    notes: Mapped[list["ReviewNote"]] = relationship(back_populates="case", cascade="all, delete-orphan")
+    notes: Mapped[list["ReviewNote"]] = relationship(
+        back_populates="case", cascade="all, delete-orphan"
+    )
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -36,7 +38,9 @@ class ReviewCase(db.Model):
             "priority": self.priority,
             "status": self.status,
             "claimed_by": self.claimed_by,
-            "lease_expires_at": self.lease_expires_at.isoformat() if self.lease_expires_at else None,
+            "lease_expires_at": self.lease_expires_at.isoformat()
+            if self.lease_expires_at
+            else None,
             "resolved_at": self.resolved_at.isoformat() if self.resolved_at else None,
             "version": self.version,
             "created_at": self.created_at.isoformat(),
@@ -47,11 +51,19 @@ class ReviewNote(db.Model):
     __tablename__ = "cookbook_review_notes"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    case_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_review_cases.id"), nullable=False)
+    case_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_review_cases.id"), nullable=False
+    )
     author: Mapped[str] = mapped_column(String(80), nullable=False)
     body: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
     case: Mapped["ReviewCase"] = relationship(back_populates="notes")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "case_id": self.case_id, "author": self.author, "body": self.body, "created_at": self.created_at.isoformat()}
+        return {
+            "id": self.id,
+            "case_id": self.case_id,
+            "author": self.author,
+            "body": self.body,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/templates/flask/06-case-triage/tests/test_app.py
+++ b/templates/flask/06-case-triage/tests/test_app.py
@@ -25,7 +25,13 @@ ReviewCase = _models.ReviewCase
 
 @pytest.fixture
 def app(tmp_path: Path):
-    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}", "SQLALCHEMY_TRACK_MODIFICATIONS": False})
+    return create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+    )
 
 
 @pytest.fixture
@@ -33,6 +39,7 @@ def httpx_client(app):
     transport = httpx.WSGITransport(app=app)
     with httpx.Client(transport=transport, base_url="http://testserver") as client:
         yield client
+
 
 class CasePayload(TypedDict):
     id: int

--- a/templates/flask/07-vendor-feed/app.py
+++ b/templates/flask/07-vendor-feed/app.py
@@ -293,9 +293,12 @@ def list_catalog_products():
 import os
 from flask import Flask
 
+
 def create_app(config=None):
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb"
+    )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     if config:
         app.config.update(config)

--- a/templates/flask/07-vendor-feed/models.py
+++ b/templates/flask/07-vendor-feed/models.py
@@ -22,10 +22,20 @@ class ImportBatch(db.Model):
     uploaded_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
     validated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     promoted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    rows: Mapped[list["ImportRow"]] = relationship(back_populates="batch", cascade="all, delete-orphan")
+    rows: Mapped[list["ImportRow"]] = relationship(
+        back_populates="batch", cascade="all, delete-orphan"
+    )
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "vendor_name": self.vendor_name, "source_filename": self.source_filename, "status": self.status, "uploaded_at": self.uploaded_at.isoformat(), "validated_at": self.validated_at.isoformat() if self.validated_at else None, "promoted_at": self.promoted_at.isoformat() if self.promoted_at else None}
+        return {
+            "id": self.id,
+            "vendor_name": self.vendor_name,
+            "source_filename": self.source_filename,
+            "status": self.status,
+            "uploaded_at": self.uploaded_at.isoformat(),
+            "validated_at": self.validated_at.isoformat() if self.validated_at else None,
+            "promoted_at": self.promoted_at.isoformat() if self.promoted_at else None,
+        }
 
 
 class ImportRow(db.Model):
@@ -33,7 +43,9 @@ class ImportRow(db.Model):
     __table_args__ = (UniqueConstraint("batch_id", "row_no", name="uq_import_rows_batch_row_no"),)
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    batch_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_import_batches.id"), nullable=False)
+    batch_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_import_batches.id"), nullable=False
+    )
     row_no: Mapped[int] = mapped_column(Integer, nullable=False)
     external_sku: Mapped[str] = mapped_column(String(100), nullable=False)
     name: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -46,12 +58,26 @@ class ImportRow(db.Model):
     batch: Mapped["ImportBatch"] = relationship(back_populates="rows")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "batch_id": self.batch_id, "row_no": self.row_no, "external_sku": self.external_sku, "name": self.name, "price_cents": self.price_cents, "raw_payload": self.raw_payload, "validation_status": self.validation_status, "error_code": self.error_code, "error_message": self.error_message, "promoted_product_id": self.promoted_product_id}
+        return {
+            "id": self.id,
+            "batch_id": self.batch_id,
+            "row_no": self.row_no,
+            "external_sku": self.external_sku,
+            "name": self.name,
+            "price_cents": self.price_cents,
+            "raw_payload": self.raw_payload,
+            "validation_status": self.validation_status,
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+            "promoted_product_id": self.promoted_product_id,
+        }
 
 
 class CatalogProduct(db.Model):
     __tablename__ = "cookbook_catalog_products"
-    __table_args__ = (UniqueConstraint("vendor_name", "external_sku", name="uq_catalog_product_vendor_sku"),)
+    __table_args__ = (
+        UniqueConstraint("vendor_name", "external_sku", name="uq_catalog_product_vendor_sku"),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     vendor_name: Mapped[str] = mapped_column(String(120), nullable=False)
@@ -61,7 +87,14 @@ class CatalogProduct(db.Model):
     active: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "vendor_name": self.vendor_name, "external_sku": self.external_sku, "name": self.name, "price_cents": self.price_cents, "active": self.active}
+        return {
+            "id": self.id,
+            "vendor_name": self.vendor_name,
+            "external_sku": self.external_sku,
+            "name": self.name,
+            "price_cents": self.price_cents,
+            "active": self.active,
+        }
 
 
 class Product(db.Model):
@@ -76,4 +109,12 @@ class Product(db.Model):
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
 
     def to_dict(self) -> dict[str, str | int]:
-        return {"id": self.id, "name": self.name, "description": self.description or "", "price": str(self.price), "category": self.category, "in_stock": self.in_stock, "created_at": self.created_at.isoformat()}
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description or "",
+            "price": str(self.price),
+            "category": self.category,
+            "in_stock": self.in_stock,
+            "created_at": self.created_at.isoformat(),
+        }

--- a/templates/flask/07-vendor-feed/tests/test_app.py
+++ b/templates/flask/07-vendor-feed/tests/test_app.py
@@ -19,7 +19,13 @@ create_app = importlib.import_module("app").create_app
 
 @pytest.fixture
 def app(tmp_path: Path):
-    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}", "SQLALCHEMY_TRACK_MODIFICATIONS": False})
+    return create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+    )
 
 
 @pytest.fixture
@@ -27,6 +33,7 @@ def httpx_client(app):
     transport = httpx.WSGITransport(app=app)
     with httpx.Client(transport=transport, base_url="http://testserver") as client:
         yield client
+
 
 class ImportBatchPayload(TypedDict):
     id: int

--- a/templates/flask/08-transactional-outbox/app.py
+++ b/templates/flask/08-transactional-outbox/app.py
@@ -253,9 +253,12 @@ def get_outbox_message(message_id: int):
 import os
 from flask import Flask
 
+
 def create_app(config=None):
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv(
+        "DATABASE_URL", "cubrid+pycubrid://dba@localhost:33000/testdb"
+    )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     if config:
         app.config.update(config)

--- a/templates/flask/08-transactional-outbox/models.py
+++ b/templates/flask/08-transactional-outbox/models.py
@@ -22,7 +22,14 @@ class Invoice(db.Model):
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "customer_email": self.customer_email, "total_cents": self.total_cents, "status": self.status, "sent_at": self.sent_at.isoformat() if self.sent_at else None, "created_at": self.created_at.isoformat()}
+        return {
+            "id": self.id,
+            "customer_email": self.customer_email,
+            "total_cents": self.total_cents,
+            "status": self.status,
+            "sent_at": self.sent_at.isoformat() if self.sent_at else None,
+            "created_at": self.created_at.isoformat(),
+        }
 
 
 class OutboxMessage(db.Model):
@@ -36,7 +43,9 @@ class OutboxMessage(db.Model):
     payload: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
     attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    next_attempt_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    next_attempt_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow
+    )
     leased_until: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     leased_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
     idempotency_key: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
@@ -46,14 +55,32 @@ class OutboxMessage(db.Model):
     attempts_list: Mapped[list["OutboxAttempt"]] = relationship(back_populates="message")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "topic": self.topic, "aggregate_type": self.aggregate_type, "aggregate_id": self.aggregate_id, "event_type": self.event_type, "payload": self.payload, "status": self.status, "attempts": self.attempts, "next_attempt_at": self.next_attempt_at.isoformat(), "leased_until": self.leased_until.isoformat() if self.leased_until else None, "leased_by": self.leased_by, "idempotency_key": self.idempotency_key, "last_error": self.last_error, "created_at": self.created_at.isoformat(), "sent_at": self.sent_at.isoformat() if self.sent_at else None}
+        return {
+            "id": self.id,
+            "topic": self.topic,
+            "aggregate_type": self.aggregate_type,
+            "aggregate_id": self.aggregate_id,
+            "event_type": self.event_type,
+            "payload": self.payload,
+            "status": self.status,
+            "attempts": self.attempts,
+            "next_attempt_at": self.next_attempt_at.isoformat(),
+            "leased_until": self.leased_until.isoformat() if self.leased_until else None,
+            "leased_by": self.leased_by,
+            "idempotency_key": self.idempotency_key,
+            "last_error": self.last_error,
+            "created_at": self.created_at.isoformat(),
+            "sent_at": self.sent_at.isoformat() if self.sent_at else None,
+        }
 
 
 class OutboxAttempt(db.Model):
     __tablename__ = "cookbook_outbox_attempts"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    outbox_message_id: Mapped[int] = mapped_column(Integer, ForeignKey("cookbook_outbox_messages.id"), nullable=False)
+    outbox_message_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("cookbook_outbox_messages.id"), nullable=False
+    )
     started_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     outcome: Mapped[str] = mapped_column(String(20), nullable=False)
@@ -61,4 +88,11 @@ class OutboxAttempt(db.Model):
     message: Mapped["OutboxMessage"] = relationship(back_populates="attempts_list")
 
     def to_dict(self) -> dict[str, object]:
-        return {"id": self.id, "outbox_message_id": self.outbox_message_id, "started_at": self.started_at.isoformat(), "finished_at": self.finished_at.isoformat() if self.finished_at else None, "outcome": self.outcome, "error_message": self.error_message}
+        return {
+            "id": self.id,
+            "outbox_message_id": self.outbox_message_id,
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "outcome": self.outcome,
+            "error_message": self.error_message,
+        }

--- a/templates/flask/08-transactional-outbox/tests/test_app.py
+++ b/templates/flask/08-transactional-outbox/tests/test_app.py
@@ -25,7 +25,13 @@ db = importlib.import_module("database").db
 
 @pytest.fixture
 def app(tmp_path: Path):
-    return create_app({"TESTING": True, "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}", "SQLALCHEMY_TRACK_MODIFICATIONS": False})
+    return create_app(
+        {
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": f"sqlite:///{tmp_path / 'test.db'}",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+    )
 
 
 @pytest.fixture
@@ -33,6 +39,7 @@ def httpx_client(app):
     transport = httpx.WSGITransport(app=app)
     with httpx.Client(transport=transport, base_url="http://testserver") as client:
         yield client
+
 
 def _create_invoice(
     httpx_client: httpx.Client,


### PR DESCRIPTION
Pins `[tool.ruff.lint] select = ["E4","E7","E9","F"]` (ruff's pre-0.16 default rule set) so routine ruff version bumps stop breaking `lint-python` with hundreds of unrelated new-rule violations. Also removes 16 genuinely-unused imports (F401), drops a dead `Base/engine` import in the saga recipe, and settles `ruff format` under 0.16.2.

Consistent with the same pin adopted in pycubrid #248 and sqlalchemy-cubrid #272.