### PR TITLE
ci: scope smoke verify to changed examples on pull requests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -73,7 +73,18 @@ jobs:
               esac
             done
             if [ -n "$MATCH" ]; then
-              case " $SELECTED " in *" $MATCH "*) : ;; *) SELECTED="$SELECTED $MATCH" ;; esac
+              # Reject any path with characters outside a safe allowlist before it
+              # reaches $GITHUB_ENV / make / find. This closes the injection and
+              # word-splitting surface from PR-controlled directory names; the
+              # allowlist excludes spaces and shell metacharacters, so the
+              # space-separated `find $(VERIFY_PATHS)` in the Makefile stays safe.
+              case "$MATCH" in
+                *[!A-Za-z0-9._/-]*)
+                  echo "Unsafe example path forces full verify: $MATCH"
+                  FALLBACK=1 ;;
+                *)
+                  case " $SELECTED " in *" $MATCH "*) : ;; *) SELECTED="$SELECTED $MATCH" ;; esac ;;
+              esac
             else
               # A file outside every example dir (Makefile, scripts/, workflow,
               # shared requirements, docs) can affect any example -> full run.

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -35,6 +35,61 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history so PR-scoped verify can diff against the base commit.
+          fetch-depth: 0
+
+      - name: Scope verify to changed examples (pull requests only)
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Non-PR events (push to main, cron, upstream release, manual dispatch)
+          # always run the full suite: a dependency bump or scheduled run must
+          # exercise every example, not just a diff.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "VERIFY_PATHS=." >> "$GITHUB_ENV"
+            echo "Full verify (event=$EVENT_NAME)"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "$PR_BASE_SHA" 2>/dev/null || true
+          CHANGED=$(git diff --name-only "$PR_BASE_SHA" HEAD)
+          echo "Changed files:"
+          printf '%s\n' "$CHANGED"
+
+          # Example roots are directories that own an expected/ folder.
+          EXROOTS=$(find . -type d -name expected -not -path '*/node_modules/*' \
+            | sed 's#/expected$##;s#^\./##' | sort -u)
+
+          SELECTED=""
+          FALLBACK=0
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            MATCH=""
+            for root in $EXROOTS; do
+              case "$f" in
+                "$root"/*) MATCH="$root"; break ;;
+              esac
+            done
+            if [ -n "$MATCH" ]; then
+              case " $SELECTED " in *" $MATCH "*) : ;; *) SELECTED="$SELECTED $MATCH" ;; esac
+            else
+              # A file outside every example dir (Makefile, scripts/, workflow,
+              # shared requirements, docs) can affect any example -> full run.
+              echo "Shared/global change forces full verify: $f"
+              FALLBACK=1
+            fi
+          done <<< "$CHANGED"
+
+          if [ "$FALLBACK" -eq 1 ] || [ -z "${SELECTED// /}" ]; then
+            echo "VERIFY_PATHS=." >> "$GITHUB_ENV"
+            echo "Full verify (fallback=$FALLBACK, selected='${SELECTED# }')"
+          else
+            echo "VERIFY_PATHS=${SELECTED# }" >> "$GITHUB_ENV"
+            echo "Scoped verify: ${SELECTED# }"
+            printf '### Scoped smoke: `%s`\n' "${SELECTED# }" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -129,7 +184,7 @@ jobs:
           PY
 
       - name: Run make verify
-        run: make verify
+        run: make verify VERIFY_PATHS="${VERIFY_PATHS:-.}"
 
       - name: Smoke test cubrid-mcp-server
         run: python -c "import cubrid_mcp_server; print('cubrid-mcp-server import OK')"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ DOCKER_COMPOSE := docker compose
 NORMALIZE := bash scripts/normalize_output.sh
 PYTHON := python3
 
+# Search roots for `make verify`. Defaults to the whole tree; CI narrows this to
+# only the changed example directories on pull requests (see smoke-test.yml).
+VERIFY_PATHS ?= .
+
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -27,10 +31,10 @@ clean: ## Stop and remove all data
 	$(DOCKER_COMPOSE) down -v
 	@echo "✓ Cleaned up all containers and volumes"
 
-verify: ## Verify example outputs against expected results
-	@echo "Verifying example outputs..."
+verify: ## Verify example outputs against expected results (VERIFY_PATHS scopes the search roots)
+	@echo "Verifying example outputs in: $(VERIFY_PATHS)"
 	@PASS=0; FAIL=0; SKIP=0; \
-	for expected in $$(find . -path '*/expected/*.expected' | sort); do \
+	for expected in $$(find $(VERIFY_PATHS) -path '*/expected/*.expected' | sort); do \
 		dir=$$(dirname "$$(dirname "$$expected")"); \
 		base=$$(basename "$$expected" .expected); \
 		script="$$dir/$$base.py"; \


### PR DESCRIPTION
## Summary

On pull requests, the smoke suite now runs `make verify` only for the example
directories touched by the diff, instead of always executing all ~23 examples.

- **PR event**: diff against the base SHA → map changed files to their owning
  example directory (a dir that has an `expected/` folder) → run only those.
- **Full-suite fallback** when any changed file is *outside* every example dir
  (Makefile, `scripts/`, workflow, shared requirements, docs) or when the diff
  touches no example dir — a shared file can affect any example.
- **Non-PR events unchanged**: push to `main`, nightly cron, `upstream-released`
  dispatch, and `workflow_dispatch` always run the full suite (a dependency bump
  must exercise every example, not a diff).

## Implementation

- `Makefile`: `verify` gains a `VERIFY_PATHS` variable (default `.`) that scopes
  the `find` roots. Full behavior is identical when unset.
- `smoke-test.yml`: `fetch-depth: 0` for base-diff; a new scoping step exports
  `VERIFY_PATHS` to `$GITHUB_ENV`; `make verify VERIFY_PATHS=...` consumes it.

## Validation

- YAML parses; `make -n verify` injects both `.` and scoped multi-path roots.
- Scoping logic unit-checked under bash (the CI shell) across 4 cases: two
  example files → scoped; example + Makefile → full; README only → full;
  empty diff → full.

Note: the dominant CI cost (CUBRID container + dependency install) is fixed, so
this trims per-example execution on focused PRs without changing release/nightly
coverage.