### PR TITLE
ci: overlap CUBRID boot with pip install and cache pip downloads

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -102,10 +102,31 @@ jobs:
             printf '### Scoped smoke: `%s`\n' "${SELECTED# }" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      - name: Start CUBRID container
+        run: |
+          # Started before dependency install so the image pull and engine
+          # initialization overlap with pip install instead of running serially;
+          # the readiness gate below then usually finds the engine already up.
+          docker run -d --name cubrid --shm-size 512m \
+            -e CUBRID_DB=testdb \
+            -p 33000:33000 -p 1523:1523 \
+            cubrid/cubrid:11.2
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          # Rolling key: the target packages float to their latest release, so
+          # this caches downloaded wheels (pandas, matplotlib, numpy, sqlalchemy)
+          # without pinning versions. pip still queries PyPI for newer releases.
+          key: pip-smoke-${{ runner.os }}-${{ hashFiles('.github/workflows/smoke-test.yml') }}
+          restore-keys: |
+            pip-smoke-${{ runner.os }}-
 
       - name: Install dependencies
         run: |
@@ -131,13 +152,6 @@ jobs:
               echo "| $pkg | ${ver:-not installed} |";
             done
           } | tee -a "$GITHUB_STEP_SUMMARY"
-
-      - name: Start CUBRID container
-        run: |
-          docker run -d --name cubrid --shm-size 512m \
-            -e CUBRID_DB=testdb \
-            -p 33000:33000 -p 1523:1523 \
-            cubrid/cubrid:11.2
 
       - name: Wait for CUBRID readiness
         run: |


### PR DESCRIPTION
## Summary

Attacks the real smoke-test bottleneck. On the last run, container boot +
dependency install was ~80s while the actual example suite ran in ~14s. This PR
targets the 80s fixed cost:

- **Overlap container boot with pip install**: the CUBRID container now starts
  *before* dependency install, so its image pull and engine initialization run
  concurrently with pip. The readiness gate afterward usually finds the engine
  already up instead of waiting on a cold start after install finishes.
- **Cache pip downloads**: `~/.cache/pip` is cached with a rolling key, so the
  large stable wheels (pandas, matplotlib, numpy, sqlalchemy) are not
  re-downloaded every run. The key is intentionally *not* version-hashed — the
  target packages (pycubrid, sqlalchemy-cubrid, cubrid-mcp-server) float to
  their latest release, and pip still queries PyPI for newer versions.

## What is unchanged

- Full-suite coverage semantics from #38 are untouched (scope step still runs
  first; `VERIFY_PATHS` logic is identical).
- The readiness gate, external-connectivity check, and `make verify` are the
  same; only step *ordering* and a cache layer changed.

## Validation

- YAML parses; step order verified: Start CUBRID → Setup Python → Cache pip →
  Install deps → Record versions → Wait readiness → external connect → verify.
- Correctness rests on the readiness gate (unchanged), which still blocks until
  `csql SELECT 1` succeeds, so starting the container earlier cannot race the
  examples.