### PR TITLE
ci: apply least-privilege token to smoke-test workflow

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,6 +14,12 @@ concurrency:
   group: smoke-tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this workflow only reads the repo and runs untrusted
+# PR-authored example code via `make verify`. A read-only token removes the
+# write/approve escalation path if that code reaches the persisted credentials.
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -38,6 +44,9 @@ jobs:
         with:
           # Full history so PR-scoped verify can diff against the base commit.
           fetch-depth: 0
+          # Do not persist GITHUB_TOKEN in .git/config: `make verify` runs
+          # untrusted PR example code, which must not be able to read the token.
+          persist-credentials: false
 
       - name: Scope verify to changed examples (pull requests only)
         env:


### PR DESCRIPTION
## Summary

- Add an explicit `permissions: contents: read` block to the `Smoke Tests` workflow (was inheriting the repo default `write` token).
- Set `persist-credentials: false` on `actions/checkout` so `GITHUB_TOKEN` is not stored in `.git/config`.

## Why

`make verify` executes **untrusted PR-authored example `.py` files**. With the default write token persisted into `.git/config`, that code could read the token and push to the repo or approve PRs. Read-only + no credential persistence closes this escalation path. No secrets are referenced by the workflow, so functionality is unaffected.

Closes #40