### PR TITLE
ci: pin cubrid-mcp-server git fallback to release tag v0.2.1

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -144,10 +144,10 @@ jobs:
           # so the released pycubrid/sqlalchemy-cubrid above are not overridden
           # by the git-pinned versions in the template requirements files.
           pip install pandas matplotlib
-          # cubrid-mcp-server publishes to PyPI on release; fall back to git
-          # until the first PyPI release is available.
+          # cubrid-mcp-server is not yet on PyPI; fall back to the pinned git
+          # release tag so the tested version is deterministic (not main HEAD).
           pip install cubrid-mcp-server \
-            || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git"
+            || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@v0.2.1"
 
       - name: Record tested versions
         run: |


### PR DESCRIPTION
## Summary
Makes the smoke-test's `cubrid-mcp-server` install deterministic (closes #43).

## Problem
`pip install cubrid-mcp-server` always fails (package not on PyPI, 404), so CI falls through to `pip install git+https://.../cubrid-mcp-server.git` — which installs **unpinned main HEAD**. The "Record tested versions" table reporting `0.2.1` was coincidental (HEAD happened to match), not a pinned release.

## Change
Pin the git fallback to the release tag: `...cubrid-mcp-server.git@v0.2.1`. Verified the tag exists upstream (`refs/tags/v0.2.1` = `ef41804`). The PyPI-first path is retained so the fallback auto-disappears once the package is published.

## Verification
- `git ls-remote --tags` confirms `v0.2.1` exists upstream.
- `smoke-test.yml` parses as valid YAML.

Closes #43