### PR TITLE
ci(smoke): restrict dispatched MCP ref to release-tag pattern

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -169,10 +169,9 @@ jobs:
               v[0-9]*.[0-9]*.[0-9]*)
                 MCP_REF="$UPSTREAM_REF"
                 MCP_DISPATCHED=1
-                echo "Using dispatched cubrid-mcp-server release ref: $MCP_REF" ;
-                *)
-                echo "Dispatched ref '$UPSTREAM_REF' is not a release tag;
-                keeping default $MCP_REF" ;;
+                echo "Using dispatched cubrid-mcp-server release ref: $MCP_REF" ;;
+              *)
+                echo "Dispatched ref '$UPSTREAM_REF' is not a release tag; keeping default $MCP_REF" ;;
             esac
           fi
           pip install cubrid-mcp-server \

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -163,9 +163,16 @@ jobs:
               # git URL, closing the command-injection surface on untrusted input.
               *[!A-Za-z0-9._/-]*)
                 echo "Dispatched ref '$UPSTREAM_REF' is unsafe; keeping default $MCP_REF" ;;
-              *)
+              # Only accept a strict release-tag pattern (vMAJOR.MINOR.PATCH) so
+              # a dispatched ref points at an actual published release, not an
+              # arbitrary branch/sha. Anything else falls back to the pinned tag.
+              v[0-9]*.[0-9]*.[0-9]*)
                 MCP_REF="$UPSTREAM_REF"
-                echo "Using dispatched cubrid-mcp-server ref: $MCP_REF" ;;
+                MCP_DISPATCHED=1
+                echo "Using dispatched cubrid-mcp-server release ref: $MCP_REF" ;
+                *)
+                echo "Dispatched ref '$UPSTREAM_REF' is not a release tag;
+                keeping default $MCP_REF" ;;
             esac
           fi
           pip install cubrid-mcp-server \


### PR DESCRIPTION
## Summary
- Restrict the `repository_dispatch` `cubrid-mcp-server` ref to a strict release-tag pattern (`vMAJOR.MINOR.PATCH`).
- Non-tag refs (branches, shas) now fall back to the pinned default `MCP_REF` instead of being installed, ensuring the dogfood always tests a published release.
- Sets `MCP_DISPATCHED=1` in the accept arm for a follow-up install-path change.

## Rationale
The previous catch-all `*)` accepted any allowlist-safe string as a ref. This tightens it so a dispatched ref must look like an actual release tag.

Closes #59

> No merge — review only.