### PR TITLE
ci(smoke): install dispatched MCP release directly from git ref

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -175,8 +175,16 @@ jobs:
                 keeping default $MCP_REF" ;;
             esac
           fi
-          pip install cubrid-mcp-server \
-            || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          # When an upstream release dispatched this run, install the exact
+          # released ref directly from git so the dogfood tests that release
+          # even before it appears on PyPI. Otherwise prefer the PyPI package
+          # and fall back to the pinned git ref.
+          if [ "${MCP_DISPATCHED:-0}" = "1" ]; then
+            pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          else
+            pip install cubrid-mcp-server \
+              || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          fi
 
       - name: Record tested versions
         run: |


### PR DESCRIPTION
## Summary
- On dispatched runs (`MCP_DISPATCHED=1` from #64), install the released `cubrid-mcp-server` ref directly from git, skipping the PyPI-first attempt.
- Non-dispatched runs keep the existing PyPI-first / git-fallback behaviour.

## Note
Stacked on #64 (`ci/mcp-ref-release-tag`). Rebase to `main` after #64 merges.

Closes #60

> No merge — review only.