### PR TITLE
ci(smoke): require health_check on MCP releases newer than v0.2.1

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -284,9 +284,10 @@ jobs:
               "list_class_hierarchy",
               "execute_query",
           }
-          # Tools added after v0.2.1 (e.g. health_check on main). Allowed but not
-          # required, so this contract stays green whether the pinned v0.2.1 tag
-          # or a newer dispatched ref (see install step) is installed.
+          # Tools added after v0.2.1 (e.g. health_check on main). Optional ONLY for
+          # the pinned v0.2.1 tag; the version gate below promotes health_check to
+          # required once a newer ref (see install step) is installed, so a newer
+          # dispatched release that drops it fails loudly.
           optional = {
               "health_check",
           }

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -175,8 +175,16 @@ jobs:
                 keeping default $MCP_REF" ;;
             esac
           fi
-          pip install cubrid-mcp-server \
-            || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          # When an upstream release dispatched this run, install the exact
+          # released ref directly from git so the dogfood tests that release
+          # even before it appears on PyPI. Otherwise prefer the PyPI package
+          # and fall back to the pinned git ref.
+          if [ "${MCP_DISPATCHED:-0}" = "1" ]; then
+            pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          else
+            pip install cubrid-mcp-server \
+              || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          fi
 
       - name: Record tested versions
         run: |

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -169,10 +169,9 @@ jobs:
               v[0-9]*.[0-9]*.[0-9]*)
                 MCP_REF="$UPSTREAM_REF"
                 MCP_DISPATCHED=1
-                echo "Using dispatched cubrid-mcp-server release ref: $MCP_REF" ;
-                *)
-                echo "Dispatched ref '$UPSTREAM_REF' is not a release tag;
-                keeping default $MCP_REF" ;;
+                echo "Using dispatched cubrid-mcp-server release ref: $MCP_REF" ;;
+              *)
+                echo "Dispatched ref '$UPSTREAM_REF' is not a release tag; keeping default $MCP_REF" ;;
             esac
           fi
           pip install cubrid-mcp-server \

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -291,6 +291,34 @@ jobs:
               "health_check",
           }
 
+          # Promote health_check from optional to required once the installed
+          # cubrid-mcp-server is newer than v0.2.1 (the release that predates it).
+          # Parse the numeric (major, minor, patch) prefix without depending on
+          # `packaging`, so a dispatched newer release must actually expose it.
+          from importlib.metadata import version as _pkg_version
+
+          def _numeric_release(raw):
+              parts = []
+              for chunk in raw.split(".")[:3]:
+                  digits = ""
+                  for ch in chunk:
+                      if ch.isdigit():
+                          digits += ch
+                      else:
+                          break
+                  parts.append(int(digits) if digits else 0)
+              while len(parts) < 3:
+                  parts.append(0)
+              return tuple(parts)
+
+          installed = _numeric_release(_pkg_version("cubrid-mcp-server"))
+          if installed > (0, 2, 1):
+              expected.add("health_check")
+              optional.discard("health_check")
+              print(
+                  f"cubrid-mcp-server {installed} > (0, 2, 1): requiring health_check tool"
+              )
+
           tools = asyncio.run(mcp.list_tools())
           names = {tool.name for tool in tools}
           print(f"cubrid-mcp-server exposes {len(names)} tools: {sorted(names)}")

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -163,9 +163,16 @@ jobs:
               # git URL, closing the command-injection surface on untrusted input.
               *[!A-Za-z0-9._/-]*)
                 echo "Dispatched ref '$UPSTREAM_REF' is unsafe; keeping default $MCP_REF" ;;
-              *)
+              # Only accept a strict release-tag pattern (vMAJOR.MINOR.PATCH) so
+              # a dispatched ref points at an actual published release, not an
+              # arbitrary branch/sha. Anything else falls back to the pinned tag.
+              v[0-9]*.[0-9]*.[0-9]*)
                 MCP_REF="$UPSTREAM_REF"
-                echo "Using dispatched cubrid-mcp-server ref: $MCP_REF" ;;
+                MCP_DISPATCHED=1
+                echo "Using dispatched cubrid-mcp-server release ref: $MCP_REF" ;
+                *)
+                echo "Dispatched ref '$UPSTREAM_REF' is not a release tag;
+                keeping default $MCP_REF" ;;
             esac
           fi
           pip install cubrid-mcp-server \


### PR DESCRIPTION
## Summary
- Promote `health_check` from optional to **required** when the installed `cubrid-mcp-server` is newer than `v0.2.1`.
- Version parsed from `importlib.metadata` with a dependency-free numeric `(major, minor, patch)` parse.
- Pinned `v0.2.1` runs stay green; a newer release that drops `health_check` now fails loudly.

## Note
Stacked on #65 → #64. Rebase to `main` after those merge.

Closes #61

> No merge — review only.