### PR TITLE
test(verify): add normalization rules for safe dynamic output (timing/path/memory)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-.PHONY: help up down status clean verify demo
+.PHONY: help up down status clean verify demo test-normalize
 
 DOCKER_COMPOSE := docker compose
 NORMALIZE := bash scripts/normalize_output.sh
@@ -62,6 +62,9 @@ verify: ## Verify example outputs against expected results (VERIFY_PATHS scopes 
 	echo ""; \
 	echo "Results: $$PASS passed, $$FAIL failed, $$SKIP skipped"; \
 	[ "$$FAIL" -eq 0 ]
+
+test-normalize: ## Run before/after unit checks for scripts/normalize_output.sh
+	bash scripts/test_normalize_output.sh
 
 demo: up verify ## Full demo: start DB, verify all examples
 	@echo ""

--- a/scripts/normalize_output.sh
+++ b/scripts/normalize_output.sh
@@ -13,6 +13,14 @@ grep -v 'SQL compilation caching' | \
 grep -v 'performance implications' | \
 grep -v 'set the .inherit_cache' | \
 grep -v 'this attribute may be set' | \
+# Presentation-only rules (below) scrub inherently dynamic, non-semantic values
+# so more examples can be golden-captured. Guardrail: only scrub run-to-run
+# noise -- never normalize values that prove behavior (SQL text, row contents,
+# exception class, transaction outcome, ordering). New rules added for:
+#   - wall-clock timings:      "... in 1.234 seconds" -> "... in {{TIME}}s"
+#   - absolute export paths:   "exported to: /abs/dir/file.csv" -> "{{PATH}}/file.csv"
+#   - tracemalloc peak memory: "peak_memory=  123.4 KB" -> "peak_memory={{MEM}} KB"
+#   - derived memory ratio:    "(largest / smallest): 12.3x" -> "...: {{RATIO}}x"
 sed -E \
   -e 's/CUBRID version: [0-9.]+/CUBRID version: {{VERSION}}/g' \
   -e 's/^(Version:[[:space:]]+)[0-9.]+/\1{{VERSION}}/g' \
@@ -28,4 +36,15 @@ sed -E \
   -e 's/[{][{]DATE[}][}] [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]+/{{TIMESTAMP}}/g' \
   -e 's/[{][{]DATE[}][}]T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+/{{DATETIME}}/g' \
   -e 's/\[generated in [0-9.]+s]/[generated in {{TIME}}s]/g' \
-  -e "s/ \(errno=-?[0-9]+, description='[^']*', sqlstate='[^']*'\)//g"
+  -e "s/ \(errno=-?[0-9]+, description='[^']*', sqlstate='[^']*'\)//g" \
+  -e 's/in [0-9]+\.[0-9]+ seconds/in {{TIME}}s/g' \
+  -e 's/in [0-9]+ seconds/in {{TIME}}s/g' \
+  -e 's#(exported to: )/[^[:space:]]*/([^/[:space:]]+)#\1{{PATH}}/\2#g' \
+  -e 's/(peak_memory=)[[:space:]]*[0-9]+\.[0-9]+ KB/\1{{MEM}} KB/g' \
+  -e 's#(memory ratio \(largest / smallest\): )[0-9]+\.[0-9]+x#\1{{RATIO}}x#g'
+
+# NOTE (Oracle B4, opt-in): generated SERIAL / AUTO_INCREMENT ids are NOT
+# normalized by default. In most examples the id value proves behavior (it is
+# row content), so scrubbing it would hide real regressions. If a specific
+# example prints an id that is genuinely incidental, add a narrowly-anchored
+# rule scoped to that example's exact label -- do not add a broad integer rule.

--- a/scripts/test_normalize_output.sh
+++ b/scripts/test_normalize_output.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Unit-style before/after checks for scripts/normalize_output.sh.
+#
+# Each case feeds a raw line through the normalizer and asserts the expected
+# normalized result. This locks in the presentation-only rules (timing, path,
+# memory, ratio) and guards against a rule accidentally scrubbing meaningful
+# data (SQL text, row contents, exception class, ordering).
+#
+# Usage: bash scripts/test_normalize_output.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NORMALIZE="bash ${SCRIPT_DIR}/normalize_output.sh"
+
+fail_count=0
+
+# assert <name> <raw-input> <expected-output>
+assert() {
+  local name="$1" raw="$2" want="$3" got
+  got="$(printf '%s\n' "$raw" | ${NORMALIZE})"
+  if [ "$got" = "$want" ]; then
+    printf 'ok   - %s\n' "$name"
+  else
+    printf 'FAIL - %s\n      raw:  %s\n      want: %s\n      got:  %s\n' \
+      "$name" "$raw" "$want" "$got"
+    fail_count=$((fail_count + 1))
+  fi
+}
+
+# --- Rules that SHOULD normalize (dynamic noise) ---
+assert "timing seconds (float)" \
+  "Report generated in 1.234 seconds" \
+  "Report generated in {{TIME}}s"
+assert "timing seconds (int)" \
+  "Report generated in 5 seconds" \
+  "Report generated in {{TIME}}s"
+assert "absolute export path" \
+  "CSV exported to: /home/runner/work/repo/fundamentals/pandas/sales.csv" \
+  "CSV exported to: {{PATH}}/sales.csv"
+assert "tracemalloc peak memory" \
+  "  fetch_size=   10  peak_memory=   123.4 KB" \
+  "  fetch_size=   10  peak_memory={{MEM}} KB"
+assert "peak memory ratio" \
+  "Peak memory ratio (largest / smallest): 12.3x" \
+  "Peak memory ratio (largest / smallest): {{RATIO}}x"
+
+# --- Guardrail: rules must NOT touch meaningful data ---
+assert "keeps SQL text" \
+  "Executing: SELECT id, name FROM users WHERE age > 30" \
+  "Executing: SELECT id, name FROM users WHERE age > 30"
+assert "keeps row contents / ids" \
+  "Row: (1, 'Alice', 30)" \
+  "Row: (1, 'Alice', 30)"
+assert "keeps exception class" \
+  "IntegrityError: UNIQUE violation" \
+  "IntegrityError: UNIQUE violation"
+assert "keeps static byte sizes" \
+  "  icon.bin        (256 bytes)" \
+  "  icon.bin        (256 bytes)"
+
+if [ "$fail_count" -ne 0 ]; then
+  printf '\n%d check(s) failed\n' "$fail_count"
+  exit 1
+fi
+printf '\nAll normalize checks passed\n'


### PR DESCRIPTION
## Summary
- Add **presentation-only** normalization rules to `scripts/normalize_output.sh` for inherently dynamic, non-semantic output:
  - wall-clock timings (`in 1.234 seconds` → `in {{TIME}}s`)
  - absolute export paths (`exported to: /abs/dir/file.csv` → `{{PATH}}/file.csv`)
  - tracemalloc peak memory (`peak_memory=  123.4 KB` → `peak_memory={{MEM}} KB`)
  - derived peak-memory ratio (`(largest / smallest): 12.3x` → `{{RATIO}}x`)
- Add `scripts/test_normalize_output.sh` with unit-style before/after checks (5 scrub cases + 4 guardrail cases) and a `make test-normalize` target.

## Guardrail (Oracle)
Rules are anchored to stable labels/units and never touch values that prove behavior (SQL text, row contents, exception class, transaction outcome, ordering). Guardrail cases assert this. Generated SERIAL/AUTO_INCREMENT ids are **not** normalized by default (documented as opt-in).

## Scope
Rules + checks only. Re-enabling specific goldens (pandas/06 path, pycubrid/15 memory) can follow once rules land.

Closes #62

> No merge — review only.