### PR TITLE
fix(isolation-levels): use MVCC string levels + add golden verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Step-by-step reference for every core operation:
 | [Async I/O](fundamentals/async/) | pycubrid.aio and SQLAlchemy async engine |
 | [Alembic migrations](fundamentals/alembic/) | Programmatic migration setup with CubridImpl |
 | [JSON type CRUD](fundamentals/json/) | Native JSON columns, JSON_EXTRACT/UNQUOTE patterns |
-| [Isolation levels](fundamentals/isolation-levels/) | 6 CUBRID levels, dirty-read demonstration |
+| [Isolation levels](fundamentals/isolation-levels/) | 3 MVCC levels, no-dirty-read demonstration |
 
 ---
 
@@ -170,7 +170,7 @@ cubrid-cookbook-python/
 │   ├── async/                 # pycubrid.aio + async SQLAlchemy
 │   ├── alembic/               # Programmatic Alembic migrations
 │   ├── json/                  # Native JSON column CRUD
-│   └── isolation-levels/      # 6 CUBRID isolation levels
+│   └── isolation-levels/      # 3 MVCC isolation levels
 └── docker-compose.yml         # CUBRID 11.2
 ```
 

--- a/fundamentals/isolation-levels/01_isolation_levels.py
+++ b/fundamentals/isolation-levels/01_isolation_levels.py
@@ -1,25 +1,29 @@
-"""01_isolation_levels.py - CUBRID isolation levels and dirty-read demonstration.
+"""01_isolation_levels.py - CUBRID isolation levels under MVCC.
 
 Demonstrates:
-- All 6 numeric isolation levels CUBRID supports (1 = most permissive, 6 = serializable)
-- Setting levels with raw SQL via pycubrid
-- Reading the current level back
-- A two-connection dirty-read demonstration at level 1 vs level 4
+- The isolation levels CUBRID accepts in raw SQL under MVCC
+- Setting a level with raw SQL via pycubrid and reading it back
+- A two-connection demonstration that dirty reads do NOT occur, even at the
+  most permissive level, because CUBRID uses MVCC snapshots
 
-CUBRID uses NUMERIC isolation levels in raw SQL:
-    SET TRANSACTION ISOLATION LEVEL <1..6>
+CUBRID uses MVCC (Multi-Version Concurrency Control). In raw SQL the level is
+set with a STRING name, not a numeric code:
 
-The mapping (per sqlalchemy-cubrid/_ISOLATION_LEVEL_MAP):
-    1 = READ COMMITTED SCHEMA, READ UNCOMMITTED INSTANCES  (dirty reads possible)
-    2 = READ COMMITTED SCHEMA, READ COMMITTED INSTANCES
-    3 = REPEATABLE READ SCHEMA, READ UNCOMMITTED INSTANCES
-    4 = REPEATABLE READ SCHEMA, READ COMMITTED INSTANCES   (CUBRID default)
-    5 = REPEATABLE READ SCHEMA, REPEATABLE READ INSTANCES
-    6 = SERIALIZABLE                                        (highest)
+    SET TRANSACTION ISOLATION LEVEL <name>
 
-Each level combines a SCHEMA stability (DDL visibility) with an INSTANCES
-stability (row-level visibility). The dual granularity is CUBRID-specific;
-most databases expose only row-level isolation.
+Only three levels are accepted under MVCC:
+    READ COMMITTED    -> snapshot per statement   (GET code 4, CUBRID default)
+    REPEATABLE READ   -> snapshot per transaction  (GET code 5)
+    SERIALIZABLE      -> full serializable         (GET code 6)
+
+READ UNCOMMITTED is intentionally rejected: MVCC readers never see another
+transaction's uncommitted changes, so dirty reads are impossible at every
+level. (Older CUBRID docs describe six numeric levels; those numeric codes are
+no longer accepted by `SET TRANSACTION ISOLATION LEVEL` under MVCC.)
+
+The current level is read back with:
+    GET TRANSACTION ISOLATION LEVEL TO x  ; SELECT x
+which returns the numeric GET code shown above.
 
 Run:
     python 01_isolation_levels.py
@@ -42,15 +46,13 @@ DB_CONFIG: dict[str, Any] = {
     "password": "",
 }
 
-# Numeric level -> human-readable name (mirrors sqlalchemy-cubrid mapping).
-LEVEL_NAMES: dict[int, str] = {
-    1: "READ COMMITTED SCHEMA, READ UNCOMMITTED INSTANCES",
-    2: "READ COMMITTED SCHEMA, READ COMMITTED INSTANCES",
-    3: "REPEATABLE READ SCHEMA, READ UNCOMMITTED INSTANCES",
-    4: "REPEATABLE READ SCHEMA, READ COMMITTED INSTANCES",
-    5: "REPEATABLE READ SCHEMA, REPEATABLE READ INSTANCES",
-    6: "SERIALIZABLE",
-}
+# The isolation levels CUBRID accepts under MVCC, in ascending strictness,
+# with the numeric code returned by GET TRANSACTION ISOLATION LEVEL.
+LEVELS: list[tuple[str, int]] = [
+    ("READ COMMITTED", 4),
+    ("REPEATABLE READ", 5),
+    ("SERIALIZABLE", 6),
+]
 
 
 def get_connection() -> Any:
@@ -82,37 +84,41 @@ def cleanup(conn: Any) -> None:
 
 
 def show_all_levels() -> None:
-    """Open a fresh connection, set each of the 6 levels, and read it back."""
+    """Open a fresh connection, set each accepted level, and read it back."""
     print()
     print("[1] Setting and reading each isolation level:")
     print()
     conn = get_connection()
     try:
-        for level in range(1, 7):
+        for name, expected_code in LEVELS:
             cur = conn.cursor()
-            cur.execute(f"SET TRANSACTION ISOLATION LEVEL {level}")
-            # CUBRID exposes the current level via the GET TRANSACTION statement.
+            cur.execute(f"SET TRANSACTION ISOLATION LEVEL {name}")
+            # CUBRID exposes the current level via the GET TRANSACTION statement,
+            # which stores the numeric code into a bind name we then SELECT.
             cur.execute("GET TRANSACTION ISOLATION LEVEL TO x")
             cur.execute("SELECT x")
             row = cur.fetchone()
             current = row[0] if row else "?"
-            name = LEVEL_NAMES.get(int(current) if isinstance(current, int) else level, "?")
-            print(f"  SET TRANSACTION ISOLATION LEVEL {level}  ->  current={current} ({name})")
+            match = "ok" if current == expected_code else f"expected {expected_code}"
+            print(f"  SET ... {name:16s} ->  GET code={current} ({match})")
             cur.close()
     finally:
         conn.close()
 
 
-def dirty_read_demo(level: int, label: str) -> None:
-    """Demonstrate whether uncommitted writes are visible at *level*.
+def no_dirty_read_demo(level: str) -> None:
+    """Show that uncommitted writes are NOT visible, even at *level*.
 
     Uses two connections on the same table:
       - writer: opens a transaction, UPDATEs the row, waits, ROLLBACKs
-      - reader: opens a transaction at *level*, reads the row BEFORE the
-        writer commits. A dirty read returns the uncommitted value.
+      - reader: opens a transaction at *level* and reads the row while the
+        writer's UPDATE is still uncommitted.
+
+    Under MVCC the reader sees the last committed value (100), never the
+    uncommitted 999 -- so no dirty read is possible.
     """
     print()
-    print(f"[2] Dirty-read demo at level {level} ({label}):")
+    print(f"[2] Dirty-read demo at {level}:")
     print()
 
     writer_done = threading.Event()
@@ -126,11 +132,9 @@ def dirty_read_demo(level: int, label: str) -> None:
             cur.execute(f"SET TRANSACTION ISOLATION LEVEL {level}")
             cur.execute("UPDATE cookbook_isolation_demo SET val = 999 WHERE id = 1")
             # Hold the write uncommitted; do NOT commit yet.
-            # Small sleep ensures the CAS broker has the row locked before
-            # the reader wakes up, eliminating a theoretical startup race.
             time.sleep(0.1)
             writer_done.set()
-            # Wait for the reader to finish its observation.
+            # Wait for the reader to finish its observation, then discard.
             reader_done.wait(timeout=5.0)
             conn.rollback()
             cur.close()
@@ -160,10 +164,10 @@ def dirty_read_demo(level: int, label: str) -> None:
     t_reader.join(timeout=10.0)
 
     val = observed.get("val")
-    if val == 999:
+    if val == 100:
+        print("  reader observed val=100 (committed value) -> no dirty read (MVCC)")
+    elif val == 999:
         print("  reader observed val=999 (UNCOMMITTED) -> dirty read OCCURRED")
-    elif val == 100:
-        print("  reader observed val=100 (committed value) -> no dirty read")
     else:
         print(f"  reader observed val={val!r} (unexpected)")
 
@@ -171,9 +175,10 @@ def dirty_read_demo(level: int, label: str) -> None:
 def main() -> None:
     print("=== CUBRID Isolation Levels Demo ===")
     print()
-    print("CUBRID supports 6 numeric isolation levels. Each combines:")
-    print("  - SCHEMA stability:  are DDL changes from other transactions visible?")
-    print("  - INSTANCES stability: are uncommitted row changes visible?")
+    print("CUBRID uses MVCC. Three isolation levels are accepted in raw SQL:")
+    print("  READ COMMITTED   - statement-level snapshot (default)")
+    print("  REPEATABLE READ  - transaction-level snapshot")
+    print("  SERIALIZABLE     - full serializable")
     print()
 
     conn = get_connection()
@@ -184,11 +189,8 @@ def main() -> None:
 
     show_all_levels()
 
-    # The most dramatic demonstration: level 1 allows dirty reads.
-    dirty_read_demo(level=1, label="READ UNCOMMITTED INSTANCES")
-
-    # At level 4 (CUBRID default) dirty reads are NOT possible.
-    dirty_read_demo(level=4, label="READ COMMITTED INSTANCES (default)")
+    # Under MVCC dirty reads are impossible even at the most permissive level.
+    no_dirty_read_demo(level="READ COMMITTED")
 
     # Cleanup.
     conn = get_connection()
@@ -199,12 +201,12 @@ def main() -> None:
 
     print()
     print("--- Choosing an isolation level ---")
-    print("  Read-heavy analytics          : level 1-2  (max throughput)")
-    print("  Typical web app (default)     : level 4   (CUBRID default)")
-    print("  Financial / consistency-critical: level 5-6 (repeatable read / serializable)")
+    print("  Read-heavy / typical web app : READ COMMITTED  (CUBRID default)")
+    print("  Consistent multi-read units  : REPEATABLE READ")
+    print("  Strict serialization         : SERIALIZABLE")
     print()
-    print("Tip: SQLAlchemy exposes human-readable names. See")
-    print("     sqlalchemy_cubrid/dialect.py:_ISOLATION_LEVEL_MAP for the mapping.")
+    print("Tip: SQLAlchemy exposes these names via")
+    print("     sqlalchemy_cubrid/dialect.py:_ISOLATION_LEVEL_MAP.")
 
 
 if __name__ == "__main__":

--- a/fundamentals/isolation-levels/expected/01_isolation_levels.expected
+++ b/fundamentals/isolation-levels/expected/01_isolation_levels.expected
@@ -1,0 +1,26 @@
+=== CUBRID Isolation Levels Demo ===
+
+CUBRID uses MVCC. Three isolation levels are accepted in raw SQL:
+  READ COMMITTED   - statement-level snapshot (default)
+  REPEATABLE READ  - transaction-level snapshot
+  SERIALIZABLE     - full serializable
+
+[setup] Created cookbook_isolation_demo with row (id=1, val=100)
+
+[1] Setting and reading each isolation level:
+
+  SET ... READ COMMITTED   ->  GET code=4 (ok)
+  SET ... REPEATABLE READ  ->  GET code=5 (ok)
+  SET ... SERIALIZABLE     ->  GET code=6 (ok)
+
+[2] Dirty-read demo at READ COMMITTED:
+
+  reader observed val=100 (committed value) -> no dirty read (MVCC)
+
+--- Choosing an isolation level ---
+  Read-heavy / typical web app : READ COMMITTED  (CUBRID default)
+  Consistent multi-read units  : REPEATABLE READ
+  Strict serialization         : SERIALIZABLE
+
+Tip: SQLAlchemy exposes these names via
+     sqlalchemy_cubrid/dialect.py:_ISOLATION_LEVEL_MAP.


### PR DESCRIPTION
## Summary
- Rewrite `fundamentals/isolation-levels/01_isolation_levels.py` to set isolation with the **string** levels CUBRID's MVCC engine accepts (`READ COMMITTED` / `REPEATABLE READ` / `SERIALIZABLE`). The old numeric form (`SET TRANSACTION ISOLATION LEVEL 1..6`) fails with `errno=-495`.
- Read each level back via `GET TRANSACTION ISOLATION LEVEL` (GET codes 4/5/6).
- Reframe the dirty-read demo as a **no-dirty-read** demonstration: under MVCC the reader always sees the committed value (100), never the uncommitted 999.
- Add captured golden `expected/01_isolation_levels.expected` so `make verify` now covers it; verified deterministic across runs.
- Update README fundamentals description `6 CUBRID levels` → `3 MVCC levels`.

## Verification
- `make verify VERIFY_PATHS="fundamentals/isolation-levels"` → 1 passed
- `ruff check` clean; output deterministic across two runs

Closes #54

> No merge — review only.