### PR TITLE
Fix collection-types example (Closes #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - Python lint errors and code formatting across all examples
 - All examples verified against live CUBRID instance
+- `fundamentals/sqlalchemy/07_collection_types.py` — SET/MULTISET/SEQUENCE collection columns now render correct single-quoted SQL literals (with quote escaping) instead of malformed inline SQL, and the example is verified against a golden `expected/07_collection_types.expected` output (Closes #56)

--- a/fundamentals/sqlalchemy/07_collection_types.py
+++ b/fundamentals/sqlalchemy/07_collection_types.py
@@ -1,20 +1,33 @@
-"""07_collection_types.py - SET, MULTISET, and SEQUENCE columns via SQLAlchemy ORM.
+"""07_collection_types.py - SET, MULTISET, and SEQUENCE columns on CUBRID.
 
 Demonstrates:
 - Defining CUBRID collection columns with sqlalchemy_cubrid.types
-- Inserting rows with collection literals
-- Querying collection membership and size
+- Inserting collection values with CUBRID collection literals (``{...}``)
+- Reading collection elements back with the ``TABLE(col)`` unnest join
 - The semantic difference between the three collection kinds
 
 CUBRID has three native collection types:
 
     SET        Unordered, NO duplicates.   e.g. unique tags on a post.
-    MULTISET   Unordered, duplicates OK.  e.g. multiset of phone numbers.
-    SEQUENCE   Ordered, duplicates OK.    e.g. ordered checklist steps.
+    MULTISET   Unordered, duplicates OK.   e.g. multiset of phone numbers.
+    SEQUENCE   Ordered, duplicates OK.     e.g. ordered checklist steps.
 
-All three are stored as a single column value and queryable with the
-IN, ANY, and COUNT operators. The ``sqlalchemy_cubrid.types`` module
-exposes them as SQLAlchemy types so ORM models can use them directly.
+Known driver limitation (why this recipe uses SQL, not ORM binding)
+-------------------------------------------------------------------
+As of the current ``pycubrid`` driver, collection columns cannot be round
+-tripped through bound parameters:
+
+  * INSERT: binding a Python ``set``/``list`` to a collection column raises
+    ``ProgrammingError("unsupported parameter type")`` in
+    ``pycubrid._cursor_common.format_parameter``.
+  * SELECT: a collection column comes back as an opaque binary-encoded
+    string, not a decoded Python list.
+
+So this recipe still models the columns with ``sqlalchemy_cubrid.types`` (the
+DDL is generated correctly), but writes values with CUBRID collection
+literals and reads them back with the ``TABLE(collection)`` unnest join,
+which returns one properly decoded element per row. If/when the driver gains
+collection parameter binding, the insert/read paths can be simplified.
 
 Run:
     python 07_collection_types.py
@@ -24,9 +37,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from sqlalchemy import Integer, String, create_engine, delete, select
-from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
-
+from sqlalchemy import Connection, Integer, String, create_engine, text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from sqlalchemy_cubrid.types import MULTISET, SEQUENCE, SET
 
 DATABASE_URL = "cubrid+pycubrid://dba@localhost:33000/testdb"
@@ -41,11 +53,35 @@ class CookbookCollectionDemo(Base):
 
     __tablename__ = "cookbook_collection_demo"
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
     title: Mapped[str] = mapped_column(String(120), nullable=False)
     tags: Mapped[Any] = mapped_column(SET(String(40)))  # unique, unordered
-    phone_numbers: Mapped[Any] = mapped_column(MULTISET(String(20)))  # duplicates OK
+    phone_numbers: Mapped[Any] = mapped_column(MULTISET(String(20)))  # dups OK
     checklist: Mapped[Any] = mapped_column(SEQUENCE(String(200)))  # ordered
+
+
+
+def _literal(value: str) -> str:
+    """Render a Python string as a single-quoted SQL literal (escapes quotes)."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _collection_literal(values: list[str]) -> str:
+    """Render a Python list as a CUBRID collection literal: ``{'a', 'b'}``."""
+    return "{" + ", ".join(_literal(v) for v in values) + "}"
+
+
+def _read_collection(conn: Connection, column: str, row_id: int) -> list[str]:
+    """Read one collection column back as a Python list via ``TABLE()`` unnest.
+
+    ``TABLE(col)`` expands a collection into one row per element, preserving
+    SEQUENCE order and MULTISET duplicates. SET elements come back in CUBRID's
+    normalized (sorted) order.
+    """
+    stmt = text(
+        f"SELECT t.elem FROM cookbook_collection_demo, TABLE({column}) AS t(elem) WHERE id = :id"
+    )
+    return [r[0] for r in conn.execute(stmt, {"id": row_id})]
 
 
 def main() -> None:
@@ -53,101 +89,115 @@ def main() -> None:
     print()
 
     engine = create_engine(DATABASE_URL)
+    Base.metadata.drop_all(engine)
     Base.metadata.create_all(engine)
     print("[1] Created table cookbook_collection_demo")
-    print("      tags         SET(40)         unique, unordered")
+    print("      tags          SET(40)        unique, unordered")
     print("      phone_numbers MULTISET(20)   duplicates allowed")
     print("      checklist     SEQUENCE(200)  ordered, duplicates allowed")
 
-    with Session(engine) as session:
-        # ------------------------------------------------------------------
-        # INSERT: Python lists/tuples bind directly to collection columns.
-        # ------------------------------------------------------------------
-        rows = [
-            CookbookCollectionDemo(
-                title="First task",
-                tags={"python", "cubrid", "demo"},
-                phone_numbers=["555-1000", "555-1000", "555-2000"],
-                checklist=["open editor", "write code", "run tests"],
-            ),
-            CookbookCollectionDemo(
-                title="Second task",
-                tags={"python", "orm"},
-                phone_numbers=["555-3000"],
-                checklist=["review PR", "merge"],
-            ),
-            CookbookCollectionDemo(
-                title="Third task",
-                tags={"rust", "systems"},
-                phone_numbers=["555-4000", "555-4000"],
-                checklist=["benchmark", "profile", "optimize", "benchmark"],
-            ),
-        ]
-        session.add_all(rows)
-        session.commit()
-        print()
-        print(f"[2] Inserted {len(rows)} rows with collection columns")
+    rows = [
+        {
+            "id": 1,
+            "title": "First task",
+            "tags": ["python", "cubrid", "demo"],
+            "phone_numbers": ["555-1000", "555-1000", "555-2000"],
+            "checklist": ["open editor", "write code", "run tests"],
+        },
+        {
+            "id": 2,
+            "title": "Second task",
+            "tags": ["python", "orm"],
+            "phone_numbers": ["555-3000"],
+            "checklist": ["review PR", "merge"],
+        },
+        {
+            "id": 3,
+            "title": "Third task",
+            "tags": ["rust", "systems"],
+            "phone_numbers": ["555-4000", "555-4000"],
+            "checklist": ["benchmark", "profile", "optimize", "benchmark"],
+        },
+    ]
 
-        # ------------------------------------------------------------------
-        # SELECT: read collections back as Python lists/tuples.
-        # ------------------------------------------------------------------
+    with engine.begin() as conn:
+        # --------------------------------------------------------------
+        # INSERT: collection values via CUBRID collection literals.
+        # (Bound set/list params are rejected by the driver; see module docstring.)
+        # --------------------------------------------------------------
+        for r in rows:
+            conn.execute(
+                text(
+                    "INSERT INTO cookbook_collection_demo "
+                    "(id, title, tags, phone_numbers, checklist) VALUES "
+                    f"({r['id']}, {_literal(r['title'])}, "
+                    f"{_collection_literal(r['tags'])}, "
+                    f"{_collection_literal(r['phone_numbers'])}, "
+                    f"{_collection_literal(r['checklist'])})"
+                )
+            )
+    print()
+    print(f"[2] Inserted {len(rows)} rows with collection columns")
+
+    with engine.connect() as conn:
+        # --------------------------------------------------------------
+        # SELECT: read collections back with the TABLE() unnest join.
+        # --------------------------------------------------------------
         print()
         print("[3] All rows:")
-        stmt = select(CookbookCollectionDemo).order_by(CookbookCollectionDemo.id)
-        for row in session.scalars(stmt):
-            print(f"    id={row.id}  title={row.title!r}")
-            print(f"      tags          = {row.tags}")
-            print(f"      phone_numbers = {row.phone_numbers}")
-            print(f"      checklist     = {row.checklist}")
+        ids = [
+            r[0] for r in conn.execute(text("SELECT id FROM cookbook_collection_demo ORDER BY id"))
+        ]
+        for row_id in ids:
+            title = conn.execute(
+                text("SELECT title FROM cookbook_collection_demo WHERE id = :id"),
+                {"id": row_id},
+            ).scalar_one()
+            print(f"    id={row_id}  title={title!r}")
+            print(f"      tags          = {_read_collection(conn, 'tags', row_id)}")
+            print(f"      phone_numbers = {_read_collection(conn, 'phone_numbers', row_id)}")
+            print(f"      checklist     = {_read_collection(conn, 'checklist', row_id)}")
 
-        # ------------------------------------------------------------------
-        # FILTER: ``IN`` predicate against a SET column.
-        #
-        # CUBRID supports ``'value' IN column`` and ``column = ALL('x')``
-        # operators on collection columns. We rely on a Python-side filter
-        # here for portability across SQLAlchemy versions.
-        # ------------------------------------------------------------------
+        # --------------------------------------------------------------
+        # FILTER: ``value IN column`` membership on a SET column (server-side).
+        # --------------------------------------------------------------
         print()
-        print("[4] Rows whose tags include 'python' (client-side filter):")
-        for row in session.scalars(
-            select(CookbookCollectionDemo).order_by(CookbookCollectionDemo.id)
+        print("[4] Rows whose tags include 'python' (server-side 'python' IN tags):")
+        for row_id, title in conn.execute(
+            text(
+                "SELECT id, title FROM cookbook_collection_demo WHERE 'python' IN tags ORDER BY id"
+            )
         ):
-            tags = set(row.tags or [])
-            if "python" in tags:
-                print(f"    id={row.id}  title={row.title!r}  tags={row.tags}")
+            tags = _read_collection(conn, "tags", row_id)
+            print(f"    id={row_id}  title={title!r}  tags={tags}")
 
-        # ------------------------------------------------------------------
+        # --------------------------------------------------------------
         # Demonstrate the SEMANTIC difference between the three kinds.
-        # ------------------------------------------------------------------
+        # --------------------------------------------------------------
         print()
         print("[5] Semantic difference (observe duplicates/ordering):")
-        first = session.scalars(
-            select(CookbookCollectionDemo).where(CookbookCollectionDemo.id == 1)
-        ).one()
-        print(f"    SET        tags         = {first.tags!r}")
-        print("                -> unique, no duplicates, no ordering guarantee")
-        print(f"    MULTISET   phone_numbers= {first.phone_numbers!r}")
+        print(f"    SET        tags          = {_read_collection(conn, 'tags', 1)}")
+        print("                -> unique, CUBRID normalizes to sorted order")
+        print(f"    MULTISET   phone_numbers = {_read_collection(conn, 'phone_numbers', 1)}")
         print("                -> duplicates PRESERVED (555-1000 appears twice)")
-        print(f"    SEQUENCE   checklist    = {first.checklist!r}")
+        print(f"    SEQUENCE   checklist     = {_read_collection(conn, 'checklist', 1)}")
         print("                -> order PRESERVED (open editor first, run tests last)")
 
-        # ------------------------------------------------------------------
-        # UPDATE: replace a collection column with a new list.
-        # ------------------------------------------------------------------
-        third = session.scalars(
-            select(CookbookCollectionDemo).where(CookbookCollectionDemo.id == 3)
-        ).one()
-        third.checklist = ["benchmark", "optimize", "benchmark", "ship"]
-        session.commit()
+    with engine.begin() as conn:
+        # --------------------------------------------------------------
+        # UPDATE: replace a collection column with a new literal value.
+        # --------------------------------------------------------------
+        new_checklist = ["benchmark", "optimize", "benchmark", "ship"]
+        conn.execute(
+            text(
+                "UPDATE cookbook_collection_demo "
+                f"SET checklist = {_collection_literal(new_checklist)} WHERE id = 3"
+            )
+        )
+    with engine.connect() as conn:
         print()
-        print(f"[6] Updated checklist for id=3: {third.checklist!r}")
+        print(f"[6] Updated checklist for id=3: {_read_collection(conn, 'checklist', 3)}")
         print("    (SEQUENCE preserves the new order and the duplicate 'benchmark')")
-
-        # ------------------------------------------------------------------
-        # Cleanup.
-        # ------------------------------------------------------------------
-        session.execute(delete(CookbookCollectionDemo))
-        session.commit()
 
     Base.metadata.drop_all(engine)
     engine.dispose()

--- a/fundamentals/sqlalchemy/07_collection_types.py
+++ b/fundamentals/sqlalchemy/07_collection_types.py
@@ -60,7 +60,6 @@ class CookbookCollectionDemo(Base):
     checklist: Mapped[Any] = mapped_column(SEQUENCE(String(200)))  # ordered
 
 
-
 def _literal(value: str) -> str:
     """Render a Python string as a single-quoted SQL literal (escapes quotes)."""
     return "'" + value.replace("'", "''") + "'"

--- a/fundamentals/sqlalchemy/expected/07_collection_types.expected
+++ b/fundamentals/sqlalchemy/expected/07_collection_types.expected
@@ -1,0 +1,46 @@
+=== CUBRID Collection Types (SET / MULTISET / SEQUENCE) ===
+
+[1] Created table cookbook_collection_demo
+      tags          SET(40)        unique, unordered
+      phone_numbers MULTISET(20)   duplicates allowed
+      checklist     SEQUENCE(200)  ordered, duplicates allowed
+
+[2] Inserted 3 rows with collection columns
+
+[3] All rows:
+    id=1  title='First task'
+      tags          = ['cubrid', 'demo', 'python']
+      phone_numbers = ['555-1000', '555-1000', '555-2000']
+      checklist     = ['open editor', 'write code', 'run tests']
+    id=2  title='Second task'
+      tags          = ['orm', 'python']
+      phone_numbers = ['555-3000']
+      checklist     = ['review PR', 'merge']
+    id=3  title='Third task'
+      tags          = ['rust', 'systems']
+      phone_numbers = ['555-4000', '555-4000']
+      checklist     = ['benchmark', 'profile', 'optimize', 'benchmark']
+
+[4] Rows whose tags include 'python' (server-side 'python' IN tags):
+    id=1  title='First task'  tags=['cubrid', 'demo', 'python']
+    id=2  title='Second task'  tags=['orm', 'python']
+
+[5] Semantic difference (observe duplicates/ordering):
+    SET        tags          = ['cubrid', 'demo', 'python']
+                -> unique, CUBRID normalizes to sorted order
+    MULTISET   phone_numbers = ['555-1000', '555-1000', '555-2000']
+                -> duplicates PRESERVED (555-1000 appears twice)
+    SEQUENCE   checklist     = ['open editor', 'write code', 'run tests']
+                -> order PRESERVED (open editor first, run tests last)
+
+[6] Updated checklist for id=3: ['benchmark', 'optimize', 'benchmark', 'ship']
+    (SEQUENCE preserves the new order and the duplicate 'benchmark')
+
+[7] Cleaned up table and closed engine
+
+--- Choosing a collection type ---
+  Need uniqueness?           -> SET
+  Duplicates meaningful?     -> MULTISET (e.g. vote tallies)
+  Insertion order matters?   -> SEQUENCE (e.g. ordered steps)
+
+See: https://www.cubrid.org/manual/en/11.2/sql/datatype.html#collection-types


### PR DESCRIPTION
## Summary
Makes `fundamentals/sqlalchemy/07_collection_types.py` runnable. It previously exited 1 because `pycubrid` cannot bind Python `set`/`list` parameters to CUBRID `SET`/`MULTISET`/`SEQUENCE` columns, and collection columns also read back as opaque binary strings.

## Approach (issue #56 option 1)
Keeps the `sqlalchemy_cubrid.types` ORM model (DDL is generated correctly) but works around the two **driver-level** limitations:
- **INSERT** via CUBRID collection literals `{...}` instead of bound params.
- **READ** via the `TABLE(collection)` unnest join, which returns properly decoded elements — preserving `SEQUENCE` order and `MULTISET` duplicates; `SET` comes back in CUBRID's normalized (sorted) order.
- Server-side `'value' IN column` membership filter.
- Both driver limitations are documented in the module docstring so readers understand why SQL is used instead of ORM binding.

## Verification
- `make verify VERIFY_PATHS="fundamentals/sqlalchemy"` → **6 passed**
- Deterministic across 2 runs (diff clean)
- `ruff check` clean
- `scripts/check_docs_sync.py` exit 0
- Adds `expected/07_collection_types.expected` golden

## Note
The underlying inability to bind/read collection params is an upstream `pycubrid`/`sqlalchemy-cubrid` limitation; a separate upstream issue can track adding native collection parameter support.

**No merge — review only.**

Closes #56