### PR TITLE
ci: add docs-sync guard to prevent stale docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,4 +21,4 @@ Make sure all items are marked when you submit the pull-request.
 - [ ] Python code passes `ruff check` and `ruff format --check`
 - [ ] No hardcoded credentials — environment variables used
 - [ ] Tests updated — new/changed examples ship an `expected/` golden file or a `tests/` suite (or an allowlist entry with a reason)
-- [ ] Docs updated — README, SUPPORT_MATRIX, and CHANGELOG reflect any added, renamed, or removed example (4-phase workflow: code without doc updates is incomplete)
+- [ ] Docs updated — README, SUPPORT_MATRIX, and CHANGELOG reflect any added, renamed, or removed example (or set `Docs: not needed - <reason>` / apply the `docs-not-needed` label; enforced by the `docs-sync` CI check)

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -17,6 +17,10 @@ jobs:
           fetch-depth: 0
 
       - name: Check behavior changes have docs updates
+        # Dependency-only Dependabot PRs never carry doc changes; exempt them so
+        # they can auto-merge. Guard on PR author (not actor) so reruns/follow-up
+        # events triggered by a human still skip enforcement for Dependabot PRs.
+        if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
         env:
           BASE_REF: ${{ github.base_ref }}
           EVENT_PATH: ${{ github.event_path }}

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,101 @@
+name: docs-sync
+
+# Fails a PR when example/behavior-relevant changes land without a matching
+# documentation update. Escape hatch: add the `docs-not-needed` label OR put
+# `Docs: not needed - <reason>` in the PR body.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  docs-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check behavior changes have docs updates
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          EVENT_PATH: ${{ github.event_path }}
+
+          # Recipe/example source + tooling. A changed example should be
+          # reflected in the support matrix / changelog / version claims.
+          IMPACT_GLOBS: |
+            fundamentals/**/*.py
+            quickstart/**/*.py
+            migration/**/*.py
+            performance/**/*.py
+            pitfalls/**/*.py
+            templates/**/*.py
+            scripts/**
+            pyproject.toml
+
+          # Docs that count as "kept in sync".
+          DOC_GLOBS: |
+            README*
+            SUPPORT_MATRIX*
+            CHANGELOG*
+            KNOWN_ISSUES*
+            GETTING_STARTED*
+            docs/**
+
+          # Changes that never require doc churn.
+          IGNORE_GLOBS: |
+            **/tests/**
+            **/expected/**
+            .github/**
+            **/*.md
+            **/*.rst
+            **/*.txt
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          python - <<'PY'
+          import fnmatch, json, os, subprocess, sys
+
+          base = f"origin/{os.environ['BASE_REF']}"
+          changed = subprocess.check_output(
+              ["git", "diff", "--name-only", f"{base}...HEAD"], text=True
+          ).splitlines()
+
+          def globs(name):
+              return [x.strip() for x in os.environ[name].splitlines() if x.strip()]
+
+          impact_globs = globs("IMPACT_GLOBS")
+          doc_globs = globs("DOC_GLOBS")
+          ignore_globs = globs("IGNORE_GLOBS")
+
+          def matches(path, patterns):
+              return any(fnmatch.fnmatch(path, pat) for pat in patterns)
+
+          event = json.load(open(os.environ["EVENT_PATH"]))
+          pr = event.get("pull_request", {})
+          labels = {label["name"] for label in pr.get("labels", [])}
+          body = pr.get("body") or ""
+
+          skipped = "docs-not-needed" in labels or "Docs: not needed -" in body
+          doc_changed = any(matches(p, doc_globs) for p in changed)
+          relevant = [
+              p for p in changed
+              if matches(p, impact_globs) and not matches(p, ignore_globs)
+          ]
+
+          print("Changed files:")
+          for p in changed:
+              print(f"  {p}")
+
+          if relevant and not doc_changed and not skipped:
+              print("\nDocs-sync guard failed.")
+              print("Example/behavior-relevant files changed without a matching docs update.")
+              print("Either update docs (SUPPORT_MATRIX / CHANGELOG / README), or add the")
+              print("`docs-not-needed` label / PR body marker:")
+              print("  Docs: not needed - <reason>")
+              print("\nRelevant files:")
+              for p in relevant:
+                  print(f"  {p}")
+              sys.exit(1)
+
+          print("\nDocs-sync guard passed.")
+          PY

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -6,7 +6,7 @@ name: docs-sync
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled, edited]
 
 jobs:
   docs-sync:
@@ -51,7 +51,7 @@ jobs:
             **/*.rst
             **/*.txt
         run: |
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF"
           python - <<'PY'
           import fnmatch, json, os, subprocess, sys
 
@@ -70,7 +70,8 @@ jobs:
           def matches(path, patterns):
               return any(fnmatch.fnmatch(path, pat) for pat in patterns)
 
-          event = json.load(open(os.environ["EVENT_PATH"]))
+          with open(os.environ["EVENT_PATH"]) as _f:
+              event = json.load(_f)
           pr = event.get("pull_request", {})
           labels = {label["name"] for label in pr.get("labels", [])}
           body = pr.get("body") or ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,14 @@ Skipping any phase requires explicit justification. Trivial changes (typos, sing
 - Verify output matches expected behavior
 - `docker compose down`
 
+## Documentation definition of done
+
+Any change that adds, renames, removes, or alters the behavior of an example — or changes supported CUBRID/driver/Python versions — MUST update the matching documentation in the **same PR**. At minimum keep in sync: `SUPPORT_MATRIX.md`, `CHANGELOG.md`, `README.md` (incl. version badges/claims), and any affected `docs/`.
+
+If no documentation change is needed, state the reason explicitly in the PR body as `Docs: not needed - <reason>` or apply the `docs-not-needed` label. This is enforced by the `docs-sync` CI check (which complements phase 3 of the workflow above).
+
+Do not mark work complete until code, tests, and documentation are consistent.
+
 ## Project Context
 
 > This repo is the **Python cookbook** for the CUBRID ecosystem.


### PR DESCRIPTION
## Summary

Adds a blocking `docs-sync` CI check so example changes cannot merge without a matching documentation update, enforcing phase 3 of the 4-phase workflow. Implements the Oracle-reviewed layered approach from #73.

## Changes

- `.github/workflows/docs-sync.yml` — fails when example `*.py` (fundamentals/quickstart/migration/performance/pitfalls/templates), `scripts/`, or `pyproject.toml` change without a `SUPPORT_MATRIX`/`CHANGELOG`/`README`/`docs` touch. Ignores tests/`expected/`, CI, and markdown-only changes. Escape hatch: `docs-not-needed` label **or** `Docs: not needed - <reason>` in the PR body.
- `AGENTS.md` — new "Documentation definition of done" section.
- `.github/pull_request_template.md` — docs checklist item now references the skip mechanism.

## Verification

- YAML parses; guard logic validated locally (same implementation as the pycubrid/sqlalchemy-cubrid guards).

## Notes

- **Do not merge** — for review only.
- `Docs: not needed - adds CI tooling only; no example/behavior change`

Closes #73