### PR TITLE
ci(smoke): install dispatched MCP release directly from git ref

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -174,8 +174,16 @@ jobs:
                 echo "Dispatched ref '$UPSTREAM_REF' is not a release tag; keeping default $MCP_REF" ;;
             esac
           fi
-          pip install cubrid-mcp-server \
-            || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          # When an upstream release dispatched this run, install the exact
+          # released ref directly from git so the dogfood tests that release
+          # even before it appears on PyPI. Otherwise prefer the PyPI package
+          # and fall back to the pinned git ref.
+          if [ "${MCP_DISPATCHED:-0}" = "1" ]; then
+            pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          else
+            pip install cubrid-mcp-server \
+              || pip install "git+https://github.com/cubrid-lab/cubrid-mcp-server.git@${MCP_REF}"
+          fi
 
       - name: Record tested versions
         run: |


### PR DESCRIPTION
## Summary
- On dispatched runs (`MCP_DISPATCHED=1` from #64), install the released `cubrid-mcp-server` ref directly from git, skipping the PyPI-first attempt.
- Non-dispatched runs keep the existing PyPI-first / git-fallback behaviour.

## Note
Supersedes #65, which auto-closed when its stacked base branch `ci/mcp-ref-release-tag` (#64) was deleted on merge. Rebuilt onto `main` with only the unique commit.

Closes #60