### PR TITLE
docs: add Python 3.14 row and sort SUPPORT_MATRIX table (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Docs
+- **SUPPORT_MATRIX Python table fixed (#81)** — added a **3.14** row and re-sorted the Python versions table into consistent descending order (3.14 → 3.9); previously 3.14 was missing and 3.13 was listed after 3.10.
 - **SUPPORT_MATRIX corrected to match CI (#72)** — the matrix claimed CUBRID 11.4 was "fully supported" and "all 62 recipes pass", but CI only runs `make verify` (46 stdout goldens) on CUBRID 11.2 / Python 3.12; the Flask/FastAPI/Streamlit/Django pytest suites and CUBRID 11.4 are never exercised in CI. Reworded the server/Python/recipe tables to state exactly what CI enforces vs. what is run manually or merely expected to work, removing the unenforced green checkmarks.
 
 ### CI

--- a/SUPPORT_MATRIX.md
+++ b/SUPPORT_MATRIX.md
@@ -26,10 +26,11 @@ Tested combinations of CUBRID server, Python version, and driver/framework.
 
 | Python | Status |
 |--------|--------|
+| **3.14** | ⚠️ Expected to work (not in CI) |
+| **3.13** | ⚠️ Expected to work (not in CI) |
 | **3.12** | ✅ Tested (CI default) |
 | **3.11** | ⚠️ Expected to work (not in CI) |
 | **3.10** | ⚠️ Minimum; expected to work (not in CI) |
-| **3.13** | ⚠️ Expected to work (not in CI) |
 | 3.9 | ❌ Not supported (`from __future__ import annotations` patterns) |
 
 ## Driver & Framework Versions


### PR DESCRIPTION
## Summary
The `SUPPORT_MATRIX.md` Python versions table was missing a **3.14** row and its ordering was scrambled (3.13 listed after 3.10).

## Changes
- `SUPPORT_MATRIX.md`: added `3.14` row (⚠️ expected to work, not in CI) and re-sorted the table descending (3.14 → 3.9)
- `CHANGELOG.md`: added `### Docs` entry

Docs: this change **is** the doc update.

Closes #81