### PR TITLE
docs: rename misleading 'Prepared statements' README link (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Docs
+- **README fundamentals link renamed to "Parameterized queries" (#82)** — the link targeting `fundamentals/parameterized-queries/` was labelled "Prepared statements", implying server-side prepare that pycubrid does not do; relabelled to "Parameterized queries" with a client-side note to match the recipe's own README warning.
 - **SUPPORT_MATRIX Python table fixed (#81)** — added a **3.14** row and re-sorted the Python versions table into consistent descending order (3.14 → 3.9); previously 3.14 was missing and 3.13 was listed after 3.10.
 - **SUPPORT_MATRIX corrected to match CI (#72)** — the matrix claimed CUBRID 11.4 was "fully supported" and "all 62 recipes pass", but CI only runs `make verify` (46 stdout goldens) on CUBRID 11.2 / Python 3.12; the Flask/FastAPI/Streamlit/Django pytest suites and CUBRID 11.4 are never exercised in CI. Reworded the server/Python/recipe tables to state exactly what CI enforces vs. what is run manually or merely expected to work, removing the unenforced green checkmarks.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Step-by-step reference for every core operation:
 | [Connecting](fundamentals/connect/) | Basic connection, metadata, context managers |
 | [CRUD](fundamentals/crud/) | INSERT, SELECT, UPDATE, DELETE with parameters |
 | [Transactions](fundamentals/transactions/) | Commit, rollback, savepoints, auto-commit |
-| [Prepared statements](fundamentals/parameterized-queries/) | Parameterized queries |
+| [Parameterized queries](fundamentals/parameterized-queries/) | Safe parameter binding (client-side, not server-side prepare) |
 | [Error handling](fundamentals/error-handling/) | Exception types, retry patterns |
 | [LOB handling](fundamentals/lob-handling/) | BLOB/CLOB operations |
 | [ORM basics](fundamentals/orm-basics/) | SQLAlchemy engine, core, ORM, relationships |


### PR DESCRIPTION
## Summary
`README.md:81` labelled the link to `fundamentals/parameterized-queries/` as "Prepared statements", implying server-side prepare — which pycubrid does not do (its README warns "Not server-side prepare"). Renamed to "Parameterized queries".

## Changes
- `README.md`: link text "Prepared statements" → "Parameterized queries"; description clarified as client-side binding
- `CHANGELOG.md`: added `### Docs` entry

Note: the tree comment (README:163) already reads "Parameterized queries", and `llms.txt` has no misleading phrasing — no other changes needed.

Docs: this change **is** the doc update.

Closes #82