### PR TITLE
docs: reconcile minimum sqlalchemy-cubrid version to >=1.0 (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Docs
+- **Reconciled the minimum `sqlalchemy-cubrid` version to `>=1.0` (#80)** — the README badge advertised `≥1.6.0` while `SUPPORT_MATRIX.md` listed `≥1.0`, and scattered `requirements.txt` files pinned stale/invalid versions (`>=2.0.0`, which does not exist; `>=0.4.1`; `>=0.3.0`). Aligned the badge and the invalid/pre-1.0 stragglers to `>=1.0` (the documented source of truth); feature-specific `>=1.4.2` pins were left unchanged.
 - **README fundamentals link renamed to "Parameterized queries" (#82)** — the link targeting `fundamentals/parameterized-queries/` was labelled "Prepared statements", implying server-side prepare that pycubrid does not do; relabelled to "Parameterized queries" with a client-side note to match the recipe's own README warning.
 - **SUPPORT_MATRIX Python table fixed (#81)** — added a **3.14** row and re-sorted the Python versions table into consistent descending order (3.14 → 3.9); previously 3.14 was missing and 3.13 was listed after 3.10.
 - **SUPPORT_MATRIX corrected to match CI (#72)** — the matrix claimed CUBRID 11.4 was "fully supported" and "all 62 recipes pass", but CI only runs `make verify` (46 stdout goldens) on CUBRID 11.2 / Python 3.12; the Flask/FastAPI/Streamlit/Django pytest suites and CUBRID 11.4 are never exercised in CI. Reworded the server/Python/recipe tables to state exactly what CI enforces vs. what is run manually or merely expected to work, removing the unenforced green checkmarks.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -22,7 +22,7 @@ FROM articles a
 ```
 
 In SQLAlchemy, `func.cardinality()` will raise a clear `CompileError` with this guidance
-(sqlalchemy-cubrid >= 0.3.0).
+(sqlalchemy-cubrid >= 1.0).
 
 In pycubrid >= 1.3.3, the error message includes a hint with the workaround.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CUBRID 11.2 | 11.4](https://img.shields.io/badge/CUBRID-11.2%20%7C%2011.4-green.svg)](SUPPORT_MATRIX.md)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 ![pycubrid](https://img.shields.io/badge/pycubrid-%E2%89%A51.6.1-blue)
-![sqlalchemy-cubrid](https://img.shields.io/badge/sqlalchemy--cubrid-%E2%89%A51.6.0-blue)
+![sqlalchemy-cubrid](https://img.shields.io/badge/sqlalchemy--cubrid-%E2%89%A51.0-blue)
 ![status](https://img.shields.io/badge/status-active%20development-yellow)
 
 ---

--- a/templates/api-service-fastapi/recipes/11-rate-limiter/requirements.txt
+++ b/templates/api-service-fastapi/recipes/11-rate-limiter/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.111.0
 uvicorn>=0.30.0
 sqlalchemy>=2.0.31
-sqlalchemy-cubrid>=0.4.1
+sqlalchemy-cubrid>=1.0
 pycubrid>=0.2.6
 pydantic>=2.8.2
 httpx>=0.27.0

--- a/templates/api-service-fastapi/recipes/12-reservation-scheduling/requirements.txt
+++ b/templates/api-service-fastapi/recipes/12-reservation-scheduling/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.111.0
 uvicorn>=0.30.0
 sqlalchemy>=2.0.31
-sqlalchemy-cubrid>=0.4.1
+sqlalchemy-cubrid>=1.0
 pycubrid>=0.2.6
 pydantic>=2.8.2
 httpx>=0.27.0

--- a/templates/api-service-fastapi/requirements.txt
+++ b/templates/api-service-fastapi/requirements.txt
@@ -2,5 +2,5 @@ fastapi>=0.111.0,<1.0.0
 uvicorn>=0.30.0,<1.0.0
 pycubrid>=0.0.4
 sqlalchemy>=2.0.0,<3.0.0
-sqlalchemy-cubrid>=2.0.0
+sqlalchemy-cubrid>=1.0
 pydantic-settings>=2.3.0,<3.0.0


### PR DESCRIPTION
## Summary
The minimum `sqlalchemy-cubrid` version was inconsistent across the repo: the README badge advertised `≥1.6.0`, `SUPPORT_MATRIX.md` listed `≥1.0`, and several `requirements.txt` files carried stale/invalid pins — including `>=2.0.0`, a release that **does not exist**.

Per Oracle review, `>=1.0` (the `SUPPORT_MATRIX.md` source of truth, with no CI/test evidence for a higher floor) is adopted as the single documented minimum.

## Changes
- `README.md`: badge `≥1.6.0` → `≥1.0`
- `SUPPORT_MATRIX.md`: unchanged (already `≥1.0`)
- `templates/api-service-fastapi/requirements.txt`: `>=2.0.0` (nonexistent) → `>=1.0`
- `templates/api-service-fastapi/recipes/11-rate-limiter/requirements.txt`: `>=0.4.1` → `>=1.0`
- `templates/api-service-fastapi/recipes/12-reservation-scheduling/requirements.txt`: `>=0.4.1` → `>=1.0`
- `KNOWN_ISSUES.md`: `>= 0.3.0` → `>= 1.0`
- `CHANGELOG.md`: added `### Docs` entry

## Out of scope
Feature-specific `>=1.4.2` recipe pins are **left unchanged** (not lowered without smoke-testing those recipes at 1.0). A follow-up can decide whether to normalize all per-recipe pins.

Docs: this change **is** the doc/config update.

Closes #80