### PR TITLE
feat: add 6 CUBRID-distinctive pycubrid examples (17-22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Added datetime-microsecond and bulk-insert timing rules to `scripts/normalize_output.sh`** — `{{DATE}} HH:MM:SS.ffffff` now normalizes to `{{DATETIME}}` and the `execute(insert, rows):`/`add_all:` perf-summary lines normalize their seconds to `{{TIME}}s`, so the merge/serial/bulk-insert examples produce reproducible goldens. Covered by new `scripts/test_normalize_output.sh` cases.
 
 ### Added
+- CUBRID-distinctive SQL feature recipes (6 new pycubrid scripts):
+  - `fundamentals/pycubrid/17_window_functions.py` — ROW_NUMBER/RANK/DENSE_RANK, LAG, running SUM over partitions (with deterministic tie-breakers)
+  - `fundamentals/pycubrid/18_recursive_cte.py` — `WITH RECURSIVE` number series and hierarchy path building (contrast with 08 CONNECT BY)
+  - `fundamentals/pycubrid/19_pagination.py` — `LIMIT`/`OFFSET` vs CUBRID-idiomatic `FOR ORDERBY_NUM() BETWEEN`, plus the `ROWNUM` caveat
+  - `fundamentals/pycubrid/20_timezone_datetime.py` — `DATETIMETZ`/`DATETIMELTZ` native reads and `SET TIME ZONE`; `TIMESTAMPTZ` rendered via server-side `TO_CHAR` to sidestep [pycubrid#289](https://github.com/cubrid-lab/pycubrid/issues/289)
+  - `fundamentals/pycubrid/21_enum_type.py` — ENUM declaration-order sorting, `col + 0` ordinal, out-of-set rejection
+  - `fundamentals/pycubrid/22_date_formatting.py` — `TO_CHAR`/`TO_DATE` date and number formatting with visible fixed-width padding
 - v1.6.x feature recipes (8 new scripts):
   - `fundamentals/async/` — pycubrid.aio + SQLAlchemy async engine
   - `fundamentals/alembic/` — programmatic Alembic migration with CubridImpl

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Step-by-step reference for every core operation:
 | [Error handling](fundamentals/error-handling/) | Exception types, retry patterns |
 | [LOB handling](fundamentals/lob-handling/) | BLOB/CLOB operations |
 | [ORM basics](fundamentals/orm-basics/) | SQLAlchemy engine, core, ORM, relationships |
-| [pycubrid driver](fundamentals/pycubrid/) | 16 DB-API recipes: cursors, fetch sizing, batch error handling |
+| [pycubrid driver](fundamentals/pycubrid/) | 22 DB-API recipes: cursors, window functions, recursive CTEs, pagination, timezone/ENUM types |
 | [SQLAlchemy recipes](fundamentals/sqlalchemy/) | 7 recipes including SET/MULTISET/SEQUENCE collection types |
 | [Pandas](fundamentals/pandas/) | 6 recipes: read_sql, chunked reads, to_sql load patterns |
 | [Async I/O](fundamentals/async/) | pycubrid.aio and SQLAlchemy async engine |
@@ -164,7 +164,7 @@ cubrid-cookbook-python/
 │   ├── error-handling/        # Exception patterns
 │   ├── lob-handling/          # BLOB/CLOB
 │   ├── orm-basics/            # SQLAlchemy ORM
-│   ├── pycubrid/              # 16 pycubrid DB-API recipes
+│   ├── pycubrid/              # 22 pycubrid DB-API recipes
 │   ├── sqlalchemy/            # 7 SQLAlchemy recipes
 │   ├── pandas/                # 6 Pandas recipes
 │   ├── async/                 # pycubrid.aio + async SQLAlchemy

--- a/fundamentals/pycubrid/17_window_functions.py
+++ b/fundamentals/pycubrid/17_window_functions.py
@@ -1,0 +1,123 @@
+"""17_window_functions.py - Analytic (window) functions.
+
+Demonstrates:
+- ROW_NUMBER() / RANK() / DENSE_RANK() ranking within partitions
+- LAG() to compare a row with the previous row
+- Running total with SUM() OVER (... ORDER BY ...)
+- Deterministic tie-breakers on ROW_NUMBER/RANK; DENSE_RANK omits one on
+  purpose to keep the West 300/300 tie visible
+"""
+
+from __future__ import annotations
+
+# pyright: reportAttributeAccessIssue=false, reportMissingImports=false
+
+import pycubrid
+
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 33000,
+    "database": "testdb",
+    "user": "dba",
+    "password": "",
+}
+
+
+def get_connection():
+    return pycubrid.connect(**DB_CONFIG)
+
+
+def setup_schema(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_sales")
+    cursor.execute(
+        """
+        CREATE TABLE cookbook_sales (
+            sale_id INT PRIMARY KEY,
+            region  VARCHAR(20) NOT NULL,
+            product VARCHAR(20) NOT NULL,
+            amount  INT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    cursor.close()
+    print("✓ Created table 'cookbook_sales'")
+
+
+def seed_sales(cursor):
+    rows = [
+        (1, "East", "Widget", 100),
+        (2, "East", "Gadget", 200),
+        (3, "East", "Gizmo", 150),
+        (4, "West", "Widget", 300),
+        (5, "West", "Gadget", 50),
+        (6, "West", "Gizmo", 300),
+    ]
+    cursor.executemany(
+        "INSERT INTO cookbook_sales (sale_id, region, product, amount) VALUES (?, ?, ?, ?)",
+        rows,
+    )
+    print(f"✓ Inserted sales rows: {len(rows)}")
+
+
+def rank_within_region(cursor):
+    # ROW_NUMBER and RANK add sale_id as a tie-breaker so results are stable.
+    # DENSE_RANK deliberately omits it: the West 300/300 tie stays a genuine tie
+    # (both rank 1), which is the point of the DENSE_RANK column here.
+    cursor.execute(
+        """
+        SELECT region, product, amount,
+               ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC, sale_id) AS rn,
+               RANK()       OVER (PARTITION BY region ORDER BY amount DESC, sale_id) AS rnk,
+               DENSE_RANK() OVER (PARTITION BY region ORDER BY amount DESC)          AS dense
+          FROM cookbook_sales
+         ORDER BY region, amount DESC, sale_id
+        """
+    )
+    print("\nRanking within each region (by amount desc):")
+    print("  region  product  amount  row_number  rank  dense_rank")
+    for region, product, amount, rn, rnk, dense in cursor.fetchall():
+        print(f"  {region:<6}  {product:<7}  {amount:>6}  {rn:>10}  {rnk:>4}  {dense:>10}")
+
+
+def running_total_and_lag(cursor):
+    cursor.execute(
+        """
+        SELECT region, product, amount,
+               LAG(amount) OVER (PARTITION BY region ORDER BY amount DESC, sale_id) AS prev_amount,
+               SUM(amount) OVER (PARTITION BY region ORDER BY amount DESC, sale_id) AS running_total
+          FROM cookbook_sales
+         ORDER BY region, amount DESC, sale_id
+        """
+    )
+    print("\nLAG and running total within each region:")
+    print("  region  product  amount  prev_amount  running_total")
+    for region, product, amount, prev_amount, running in cursor.fetchall():
+        prev_str = "(none)" if prev_amount is None else str(prev_amount)
+        print(f"  {region:<6}  {product:<7}  {amount:>6}  {prev_str:>11}  {running:>13}")
+
+
+def cleanup(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_sales")
+    conn.commit()
+    cursor.close()
+    print("\n✓ Cleaned up table 'cookbook_sales'")
+
+
+if __name__ == "__main__":
+    conn = get_connection()
+
+    try:
+        setup_schema(conn)
+        cursor = conn.cursor()
+        seed_sales(cursor)
+        conn.commit()
+        rank_within_region(cursor)
+        running_total_and_lag(cursor)
+        cursor.close()
+    finally:
+        cleanup(conn)
+        conn.close()

--- a/fundamentals/pycubrid/18_recursive_cte.py
+++ b/fundamentals/pycubrid/18_recursive_cte.py
@@ -1,0 +1,128 @@
+"""18_recursive_cte.py - Recursive common table expressions (WITH RECURSIVE).
+
+Demonstrates:
+- A generated number series with an anchor + recursive member
+- Walking a parent/child hierarchy and building a materialized path
+- How WITH RECURSIVE contrasts with START WITH ... CONNECT BY (see 08)
+
+CUBRID supports BOTH the ANSI recursive CTE shown here and Oracle-style
+CONNECT BY. Recursive CTEs are portable across engines; CONNECT BY is terser
+for pure tree walks.
+"""
+
+from __future__ import annotations
+
+# pyright: reportAttributeAccessIssue=false, reportMissingImports=false
+
+import pycubrid
+
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 33000,
+    "database": "testdb",
+    "user": "dba",
+    "password": "",
+}
+
+
+def get_connection():
+    return pycubrid.connect(**DB_CONFIG)
+
+
+def number_series(cursor):
+    # Anchor (SELECT 1) + recursive member (n + 1) bounded by n < 5.
+    cursor.execute(
+        """
+        WITH RECURSIVE nums (n) AS (
+            SELECT 1
+            UNION ALL
+            SELECT n + 1 FROM nums WHERE n < 5
+        )
+        SELECT n FROM nums ORDER BY n
+        """
+    )
+    values = [row[0] for row in cursor.fetchall()]
+    print(f"\nGenerated number series: {values}")
+
+
+def setup_schema(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_employees")
+    cursor.execute(
+        """
+        CREATE TABLE cookbook_employees (
+            id       INT PRIMARY KEY,
+            name     VARCHAR(50) NOT NULL,
+            mgr_id   INT
+        )
+        """
+    )
+    conn.commit()
+    cursor.close()
+    print("✓ Created table 'cookbook_employees'")
+
+
+def seed_employees(cursor):
+    rows = [
+        (1, "Alice", None),
+        (2, "Bob", 1),
+        (3, "Carol", 1),
+        (4, "Dave", 2),
+        (5, "Eve", 2),
+        (6, "Frank", 3),
+    ]
+    cursor.executemany(
+        "INSERT INTO cookbook_employees (id, name, mgr_id) VALUES (?, ?, ?)",
+        rows,
+    )
+    print(f"✓ Inserted employees: {len(rows)}")
+
+
+def walk_hierarchy(cursor):
+    # The recursive member joins each employee to its manager's accumulated path.
+    cursor.execute(
+        """
+        WITH RECURSIVE org (id, name, mgr_id, lvl, path) AS (
+            SELECT id, name, mgr_id, 1, CAST(name AS VARCHAR(200))
+              FROM cookbook_employees
+             WHERE mgr_id IS NULL
+            UNION ALL
+            SELECT e.id, e.name, e.mgr_id, o.lvl + 1, o.path || ' > ' || e.name
+              FROM cookbook_employees e
+              JOIN org o ON e.mgr_id = o.id
+        )
+        SELECT lvl, id, name, path FROM org ORDER BY path
+        """
+    )
+    print("\nOrg hierarchy (ordered by path):")
+    for lvl, emp_id, name, path in cursor.fetchall():
+        indent = "  " * (lvl - 1)
+        print(f"  {indent}- id={emp_id} depth={lvl} path={path}")
+
+
+def cleanup(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_employees")
+    conn.commit()
+    cursor.close()
+    print("\n✓ Cleaned up table 'cookbook_employees'")
+
+
+if __name__ == "__main__":
+    conn = get_connection()
+
+    try:
+        cursor = conn.cursor()
+        number_series(cursor)
+        cursor.close()
+
+        setup_schema(conn)
+        cursor = conn.cursor()
+        seed_employees(cursor)
+        conn.commit()
+        walk_hierarchy(cursor)
+        cursor.close()
+    finally:
+        cleanup(conn)
+        conn.close()

--- a/fundamentals/pycubrid/19_pagination.py
+++ b/fundamentals/pycubrid/19_pagination.py
@@ -1,0 +1,116 @@
+"""19_pagination.py - Server-side pagination idioms in CUBRID.
+
+Demonstrates:
+- Portable LIMIT ... OFFSET paging
+- CUBRID-idiomatic FOR ORDERBY_NUM() BETWEEN ... AND ... paging
+- Why the two return the SAME ordered page
+- A note on ROWNUM (assigned BEFORE ORDER BY, so it is not a paging tool)
+
+Rule of thumb: always ORDER BY a unique key before paging, otherwise the
+"page" is undefined.
+"""
+
+from __future__ import annotations
+
+# pyright: reportAttributeAccessIssue=false, reportMissingImports=false
+
+import pycubrid
+
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 33000,
+    "database": "testdb",
+    "user": "dba",
+    "password": "",
+}
+
+PAGE_SIZE = 3
+
+
+def get_connection():
+    return pycubrid.connect(**DB_CONFIG)
+
+
+def setup_schema(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_catalog")
+    cursor.execute(
+        """
+        CREATE TABLE cookbook_catalog (
+            id   INT PRIMARY KEY,
+            name VARCHAR(40) NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    cursor.close()
+    print("✓ Created table 'cookbook_catalog'")
+
+
+def seed_catalog(cursor):
+    rows = [(i, f"item-{i:02d}") for i in range(1, 11)]
+    cursor.executemany("INSERT INTO cookbook_catalog (id, name) VALUES (?, ?)", rows)
+    print(f"✓ Inserted catalog rows: {len(rows)}")
+
+
+def page_with_limit_offset(cursor, page):
+    offset = (page - 1) * PAGE_SIZE
+    cursor.execute(
+        """
+        SELECT id, name FROM cookbook_catalog
+         ORDER BY id
+         LIMIT ? OFFSET ?
+        """,
+        (PAGE_SIZE, offset),
+    )
+    return cursor.fetchall()
+
+
+def page_with_orderby_num(cursor, page):
+    lo = (page - 1) * PAGE_SIZE + 1
+    hi = page * PAGE_SIZE
+    # ORDERBY_NUM() is assigned AFTER the ORDER BY, so it pages an ordered set.
+    cursor.execute(
+        """
+        SELECT id, name FROM cookbook_catalog
+         ORDER BY id
+           FOR ORDERBY_NUM() BETWEEN ? AND ?
+        """,
+        (lo, hi),
+    )
+    return cursor.fetchall()
+
+
+def show_pages(cursor):
+    for page in (1, 2, 3):
+        lo = page_with_limit_offset(cursor, page)
+        ob = page_with_orderby_num(cursor, page)
+        match = "same" if lo == ob else "DIFFERENT"
+        print(f"\nPage {page} (size {PAGE_SIZE}):")
+        print(f"  LIMIT/OFFSET : {[r[1] for r in lo]}")
+        print(f"  ORDERBY_NUM  : {[r[1] for r in ob]}")
+        print(f"  -> both idioms agree: {match}")
+
+
+def cleanup(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_catalog")
+    conn.commit()
+    cursor.close()
+    print("\n✓ Cleaned up table 'cookbook_catalog'")
+
+
+if __name__ == "__main__":
+    conn = get_connection()
+
+    try:
+        setup_schema(conn)
+        cursor = conn.cursor()
+        seed_catalog(cursor)
+        conn.commit()
+        show_pages(cursor)
+        cursor.close()
+    finally:
+        cleanup(conn)
+        conn.close()

--- a/fundamentals/pycubrid/20_timezone_datetime.py
+++ b/fundamentals/pycubrid/20_timezone_datetime.py
@@ -1,0 +1,134 @@
+"""20_timezone_datetime.py - Timezone-aware datetime types.
+
+Demonstrates:
+- SET TIME ZONE to pin the session zone (makes *LTZ values deterministic)
+- DATETIMETZ: stores an explicit zone, read back as a tz-aware datetime
+- DATETIMELTZ: stored in UTC; pycubrid materializes native reads as UTC-aware
+  (+00:00) datetimes. Server-side formatting (TO_CHAR) is the path for rendering
+  in the pinned session zone.
+- Server-side TO_CHAR rendering with the TZR (zone-region) format element
+
+Note on TIMESTAMPTZ / TIMESTAMPLTZ:
+    Reading those two column types natively currently triggers a pycubrid
+    parsing bug (cubrid-lab/pycubrid#289), so this recipe reads TIMESTAMPTZ
+    only via server-side TO_CHAR(), which is unaffected. DATETIMETZ and
+    DATETIMELTZ read back natively without issue.
+"""
+
+from __future__ import annotations
+
+# pyright: reportAttributeAccessIssue=false, reportMissingImports=false
+
+import pycubrid
+
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 33000,
+    "database": "testdb",
+    "user": "dba",
+    "password": "",
+}
+
+SESSION_TZ = "Asia/Seoul"
+
+
+def get_connection():
+    return pycubrid.connect(**DB_CONFIG)
+
+
+def pin_session_zone(cursor):
+    # Session-scoped: makes DATETIMELTZ rendering independent of the server's OS zone.
+    cursor.execute(f"SET TIME ZONE '{SESSION_TZ}'")
+    print(f"✓ Session time zone pinned to '{SESSION_TZ}'")
+
+
+def setup_schema(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_events")
+    cursor.execute(
+        """
+        CREATE TABLE cookbook_events (
+            id      INT PRIMARY KEY,
+            label   VARCHAR(30) NOT NULL,
+            at_tz   DATETIMETZ NOT NULL,
+            at_ltz  DATETIMELTZ NOT NULL,
+            at_ts   TIMESTAMPTZ NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    cursor.close()
+    print("✓ Created table 'cookbook_events'")
+
+
+def seed_events(cursor):
+    cursor.execute(
+        """
+        INSERT INTO cookbook_events (id, label, at_tz, at_ltz, at_ts) VALUES
+            (1, 'seoul-launch',
+             DATETIMETZ '2026-01-15 10:30:00 Asia/Seoul',
+             DATETIMELTZ '2026-01-15 10:30:00',
+             TIMESTAMPTZ '2026-01-15 10:30:00 Asia/Seoul'),
+            (2, 'utc-batch',
+             DATETIMETZ '2026-01-15 10:30:00 UTC',
+             DATETIMELTZ '2026-01-15 01:30:00',
+             TIMESTAMPTZ '2026-01-15 10:30:00 UTC')
+        """
+    )
+    print("✓ Inserted events: 2")
+
+
+def read_native(cursor):
+    # DATETIMETZ keeps its explicit zone; DATETIMELTZ comes back UTC-aware (+00:00)
+    # from the driver, not in the session zone. Use TO_CHAR server-side for that.
+    cursor.execute("SELECT id, label, at_tz, at_ltz FROM cookbook_events ORDER BY id")
+    print("\nNative tz-aware datetimes (DATETIMETZ, DATETIMELTZ):")
+    for event_id, label, at_tz, at_ltz in cursor.fetchall():
+        tz_str = at_tz.isoformat(sep=" ", timespec="seconds")
+        ltz_str = at_ltz.isoformat(sep=" ", timespec="seconds")
+        print(f"  id={event_id} {label:<12} tz={tz_str}  ltz={ltz_str}")
+
+
+def read_via_to_char(cursor):
+    # TIMESTAMPTZ rendered server-side to sidestep pycubrid#289.
+    cursor.execute(
+        """
+        SELECT id, label,
+               TO_CHAR(at_ts, 'YYYY-MM-DD HH24:MI:SS TZR')
+          FROM cookbook_events
+         ORDER BY id
+        """
+    )
+    print("\nTIMESTAMPTZ via server-side TO_CHAR (zone region):")
+    for event_id, label, rendered in cursor.fetchall():
+        print(f"  id={event_id} {label:<12} ts={rendered}")
+
+
+def cleanup(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_events")
+    conn.commit()
+    cursor.close()
+    print("\n✓ Cleaned up table 'cookbook_events'")
+
+
+if __name__ == "__main__":
+    conn = get_connection()
+
+    try:
+        cursor = conn.cursor()
+        pin_session_zone(cursor)
+        cursor.close()
+
+        setup_schema(conn)
+        cursor = conn.cursor()
+        pin_session_zone(cursor)
+        seed_events(cursor)
+        conn.commit()
+        read_native(cursor)
+        read_via_to_char(cursor)
+        cursor.close()
+    finally:
+        cleanup(conn)
+        conn.close()

--- a/fundamentals/pycubrid/21_enum_type.py
+++ b/fundamentals/pycubrid/21_enum_type.py
@@ -1,0 +1,114 @@
+"""21_enum_type.py - The ENUM column type.
+
+Demonstrates:
+- Declaring an ENUM column with an ordered set of allowed string values
+- Ordering by an ENUM sorts by DECLARATION order, not alphabetically
+- Recovering the 1-based ordinal of a value with `col + 0`
+- Rejecting a value outside the declared set
+
+The declaration order IS the sort/priority order, which makes ENUM a compact
+way to model ranked categorical values (priority, severity, size, ...).
+"""
+
+from __future__ import annotations
+
+# pyright: reportAttributeAccessIssue=false, reportMissingImports=false
+
+import pycubrid
+
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 33000,
+    "database": "testdb",
+    "user": "dba",
+    "password": "",
+}
+
+
+def get_connection():
+    return pycubrid.connect(**DB_CONFIG)
+
+
+def setup_schema(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_tickets")
+    cursor.execute(
+        """
+        CREATE TABLE cookbook_tickets (
+            id       INT PRIMARY KEY,
+            title    VARCHAR(40) NOT NULL,
+            priority ENUM('low', 'medium', 'high', 'critical') NOT NULL
+        )
+        """
+    )
+    conn.commit()
+    cursor.close()
+    print("✓ Created table 'cookbook_tickets'")
+
+
+def seed_tickets(cursor):
+    rows = [
+        (1, "Typo in footer", "low"),
+        (2, "Login sometimes fails", "high"),
+        (3, "DB is down", "critical"),
+        (4, "Slow dashboard", "medium"),
+    ]
+    cursor.executemany(
+        "INSERT INTO cookbook_tickets (id, title, priority) VALUES (?, ?, ?)",
+        rows,
+    )
+    print(f"✓ Inserted tickets: {len(rows)}")
+
+
+def order_by_enum(cursor):
+    # ORDER BY priority uses declaration order: low < medium < high < critical.
+    cursor.execute(
+        """
+        SELECT id, title, priority, priority + 0 AS ordinal
+          FROM cookbook_tickets
+         ORDER BY priority DESC, id
+        """
+    )
+    print("\nTickets by priority (highest first):")
+    print("  ordinal  priority  title")
+    for _id, title, priority, ordinal in cursor.fetchall():
+        print(f"  {ordinal:>7}  {priority:<8}  {title}")
+
+
+def reject_invalid(cursor, conn):
+    print("\nInserting an out-of-set value ('urgent'):")
+    try:
+        cursor.execute(
+            "INSERT INTO cookbook_tickets (id, title, priority) VALUES (?, ?, ?)",
+            (99, "Bad value", "urgent"),
+        )
+        conn.commit()
+        print("  (unexpected) insert succeeded")
+    except pycubrid.DatabaseError as exc:
+        conn.rollback()
+        print(f"  rejected by ENUM constraint: {type(exc).__name__}")
+
+
+def cleanup(conn):
+    cursor = conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS cookbook_tickets")
+    conn.commit()
+    cursor.close()
+    print("\n✓ Cleaned up table 'cookbook_tickets'")
+
+
+if __name__ == "__main__":
+    conn = get_connection()
+
+    try:
+        setup_schema(conn)
+        cursor = conn.cursor()
+        seed_tickets(cursor)
+        conn.commit()
+        order_by_enum(cursor)
+        reject_invalid(cursor, conn)
+        cursor.close()
+    finally:
+        cleanup(conn)
+        conn.close()

--- a/fundamentals/pycubrid/22_date_formatting.py
+++ b/fundamentals/pycubrid/22_date_formatting.py
@@ -1,0 +1,90 @@
+"""22_date_formatting.py - Formatting and parsing dates with TO_CHAR / TO_DATE.
+
+Demonstrates:
+- TO_CHAR(date, fmt) to render dates and datetimes in several layouts
+- TO_DATE(str, fmt) to parse strings in one layout, then re-render in another
+- TO_CHAR(number, fmt) for grouped/padded numeric formatting
+- How fixed-width format elements pad output (shown with |...| delimiters)
+
+Values are wrapped in | | so the exact output produced by CUBRID is visible
+and verifiable. NUMERIC/DECIMAL is used instead of float to keep output exact.
+"""
+
+from __future__ import annotations
+
+# pyright: reportAttributeAccessIssue=false, reportMissingImports=false
+
+import pycubrid
+
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 33000,
+    "database": "testdb",
+    "user": "dba",
+    "password": "",
+}
+
+
+def get_connection():
+    return pycubrid.connect(**DB_CONFIG)
+
+
+def format_dates(cursor):
+    cursor.execute(
+        """
+        SELECT
+            TO_CHAR(DATE '2026-01-15', 'DD/MM/YYYY'),
+            TO_CHAR(DATE '2026-01-15', 'MM-DD-YYYY'),
+            TO_CHAR(DATETIME '2026-01-15 14:05:09', 'YYYY/MM/DD HH24:MI:SS')
+        """
+    )
+    dmy, mdy, dt = cursor.fetchone()
+    print("\nTO_CHAR date/datetime formatting (| | shows exact output):")
+    print(f"  DD/MM/YYYY     |{dmy}|")
+    print(f"  MM-DD-YYYY     |{mdy}|")
+    print(f"  datetime       |{dt}|")
+
+
+
+def parse_dates(cursor):
+    cursor.execute(
+        """
+        SELECT
+            TO_CHAR(TO_DATE('15-01-2026', 'DD-MM-YYYY'), 'YYYY/MM/DD'),
+            TO_CHAR(TO_DATE('20260115', 'YYYYMMDD'), 'MM-DD-YYYY')
+        """
+    )
+    a, b = cursor.fetchone()
+    print("\nTO_DATE parsing (parse one layout, re-render in another):")
+    print(f"  '15-01-2026' (DD-MM-YYYY) -> |{a}| (YYYY/MM/DD)")
+    print(f"  '20260115'   (YYYYMMDD)  -> |{b}| (MM-DD-YYYY)")
+
+
+def format_numbers(cursor):
+    cursor.execute(
+        """
+        SELECT
+            TO_CHAR(CAST(1234567.89 AS NUMERIC(12,2)), '9,999,999.99'),
+            TO_CHAR(CAST(1234567.89 AS NUMERIC(12,2)), '999,999,999.99'),
+            TO_CHAR(CAST(1234567.89 AS NUMERIC(12,2)), '099,999,999.99')
+        """
+    )
+    grouped, padded, zero = cursor.fetchone()
+    print("\nTO_CHAR numeric formatting (| | shows padding):")
+    print(f"  grouped        |{grouped}|")
+    print(f"  space-padded   |{padded}|")
+    print(f"  zero-padded    |{zero}|")
+
+
+if __name__ == "__main__":
+    conn = get_connection()
+
+    try:
+        cursor = conn.cursor()
+        format_dates(cursor)
+        parse_dates(cursor)
+        format_numbers(cursor)
+        cursor.close()
+    finally:
+        conn.close()

--- a/fundamentals/pycubrid/22_date_formatting.py
+++ b/fundamentals/pycubrid/22_date_formatting.py
@@ -46,7 +46,6 @@ def format_dates(cursor):
     print(f"  datetime       |{dt}|")
 
 
-
 def parse_dates(cursor):
     cursor.execute(
         """

--- a/fundamentals/pycubrid/README.md
+++ b/fundamentals/pycubrid/README.md
@@ -48,6 +48,12 @@ pip install -r requirements.txt
 | `14_manual_cascade_delete.py` | App-managed cascades | child-first deletes, preview counts, CUBRID no-CASCADE workaround |
 | `15_cursor_memory_bound.py` | Bounded fetch with ``fetch_size`` | tracemalloc, fetch_size vs arraysize, peak-memory comparison |
 | `16_batch_error_handling.py` | All-or-nothing batch recovery | ``executemany_batch`` error paths, `rollback()` for all-or-nothing semantics |
+| `17_window_functions.py` | Analytic (window) functions | `ROW_NUMBER`/`RANK`/`DENSE_RANK`, `LAG`, running `SUM` `OVER (PARTITION BY ... ORDER BY ...)` |
+| `18_recursive_cte.py` | Recursive CTEs | `WITH RECURSIVE`, number series, hierarchy path building (contrast with 08 CONNECT BY) |
+| `19_pagination.py` | Server-side pagination | `LIMIT`/`OFFSET` vs CUBRID `FOR ORDERBY_NUM() BETWEEN`, `ROWNUM` caveat |
+| `20_timezone_datetime.py` | Timezone-aware datetimes | `DATETIMETZ`/`DATETIMELTZ`, `SET TIME ZONE`, `TO_CHAR(... TZR)` |
+| `21_enum_type.py` | The ENUM column type | declaration-order sorting, `col + 0` ordinal, out-of-set rejection |
+| `22_date_formatting.py` | Date formatting & parsing | `TO_CHAR(date/number, fmt)`, `TO_DATE(str, fmt)`, fixed-width padding |
 
 ## Run
 

--- a/fundamentals/pycubrid/expected/17_window_functions.expected
+++ b/fundamentals/pycubrid/expected/17_window_functions.expected
@@ -1,0 +1,22 @@
+✓ Created table 'cookbook_sales'
+✓ Inserted sales rows: 6
+
+Ranking within each region (by amount desc):
+  region  product  amount  row_number  rank  dense_rank
+  East    Gadget      200           1     1           1
+  East    Gizmo       150           2     2           2
+  East    Widget      100           3     3           3
+  West    Widget      300           1     1           1
+  West    Gizmo       300           2     2           1
+  West    Gadget       50           3     3           2
+
+LAG and running total within each region:
+  region  product  amount  prev_amount  running_total
+  East    Gadget      200       (none)            200
+  East    Gizmo       150          200            350
+  East    Widget      100          150            450
+  West    Widget      300       (none)            300
+  West    Gizmo       300          300            600
+  West    Gadget       50          300            650
+
+✓ Cleaned up table 'cookbook_sales'

--- a/fundamentals/pycubrid/expected/18_recursive_cte.expected
+++ b/fundamentals/pycubrid/expected/18_recursive_cte.expected
@@ -1,0 +1,14 @@
+
+Generated number series: [1, 2, 3, 4, 5]
+✓ Created table 'cookbook_employees'
+✓ Inserted employees: 6
+
+Org hierarchy (ordered by path):
+  - id=1 depth=1 path=Alice
+    - id=2 depth=2 path=Alice > Bob
+      - id=4 depth=3 path=Alice > Bob > Dave
+      - id=5 depth=3 path=Alice > Bob > Eve
+    - id=3 depth=2 path=Alice > Carol
+      - id=6 depth=3 path=Alice > Carol > Frank
+
+✓ Cleaned up table 'cookbook_employees'

--- a/fundamentals/pycubrid/expected/19_pagination.expected
+++ b/fundamentals/pycubrid/expected/19_pagination.expected
@@ -1,0 +1,19 @@
+✓ Created table 'cookbook_catalog'
+✓ Inserted catalog rows: 10
+
+Page 1 (size 3):
+  LIMIT/OFFSET : ['item-01', 'item-02', 'item-03']
+  ORDERBY_NUM  : ['item-01', 'item-02', 'item-03']
+  -> both idioms agree: same
+
+Page 2 (size 3):
+  LIMIT/OFFSET : ['item-04', 'item-05', 'item-06']
+  ORDERBY_NUM  : ['item-04', 'item-05', 'item-06']
+  -> both idioms agree: same
+
+Page 3 (size 3):
+  LIMIT/OFFSET : ['item-07', 'item-08', 'item-09']
+  ORDERBY_NUM  : ['item-07', 'item-08', 'item-09']
+  -> both idioms agree: same
+
+✓ Cleaned up table 'cookbook_catalog'

--- a/fundamentals/pycubrid/expected/20_timezone_datetime.expected
+++ b/fundamentals/pycubrid/expected/20_timezone_datetime.expected
@@ -1,0 +1,14 @@
+✓ Session time zone pinned to 'Asia/Seoul'
+✓ Created table 'cookbook_events'
+✓ Session time zone pinned to 'Asia/Seoul'
+✓ Inserted events: 2
+
+Native tz-aware datetimes (DATETIMETZ, DATETIMELTZ):
+  id=1 seoul-launch tz={{DATE}} 10:30:00+09:00  ltz={{DATE}} 01:30:00+00:00
+  id=2 utc-batch    tz={{DATE}} 10:30:00+00:00  ltz={{DATE}} 16:30:00+00:00
+
+TIMESTAMPTZ via server-side TO_CHAR (zone region):
+  id=1 seoul-launch ts={{DATE}} 10:30:00 Asia/Seoul
+  id=2 utc-batch    ts={{DATE}} 10:30:00 UTC
+
+✓ Cleaned up table 'cookbook_events'

--- a/fundamentals/pycubrid/expected/21_enum_type.expected
+++ b/fundamentals/pycubrid/expected/21_enum_type.expected
@@ -1,0 +1,14 @@
+✓ Created table 'cookbook_tickets'
+✓ Inserted tickets: 4
+
+Tickets by priority (highest first):
+  ordinal  priority  title
+        4  critical  DB is down
+        3  high      Login sometimes fails
+        2  medium    Slow dashboard
+        1  low       Typo in footer
+
+Inserting an out-of-set value ('urgent'):
+  rejected by ENUM constraint: ProgrammingError
+
+✓ Cleaned up table 'cookbook_tickets'

--- a/fundamentals/pycubrid/expected/22_date_formatting.expected
+++ b/fundamentals/pycubrid/expected/22_date_formatting.expected
@@ -1,0 +1,14 @@
+
+TO_CHAR date/datetime formatting (| | shows exact output):
+  DD/MM/YYYY     |15/01/2026|
+  MM-DD-YYYY     |01-15-2026|
+  datetime       |2026/01/15 14:05:09|
+
+TO_DATE parsing (parse one layout, re-render in another):
+  '15-01-2026' (DD-MM-YYYY) -> |2026/01/15| (YYYY/MM/DD)
+  '20260115'   (YYYYMMDD)  -> |01-15-2026| (MM-DD-YYYY)
+
+TO_CHAR numeric formatting (| | shows padding):
+  grouped        |1,234,567.89|
+  space-padded   |  1,234,567.89|
+  zero-padded    |001,234,567.89|


### PR DESCRIPTION
## Summary

Adds 6 new pycubrid cookbook examples covering CUBRID-distinctive features that were not previously demonstrated:

| File | Topic |
|------|-------|
| `17_window_functions.py` | `ROW_NUMBER`/`RANK`/`DENSE_RANK`, `LAG`, running `SUM` `OVER (PARTITION BY ... ORDER BY ...)` |
| `18_recursive_cte.py` | `WITH RECURSIVE` number series + hierarchy path building (contrast with 08 CONNECT BY) |
| `19_pagination.py` | `LIMIT`/`OFFSET` vs CUBRID `FOR ORDERBY_NUM() BETWEEN`, `ROWNUM` caveat |
| `20_timezone_datetime.py` | `DATETIMETZ`/`DATETIMELTZ`, `SET TIME ZONE`, `TO_CHAR(... TZR)` |
| `21_enum_type.py` | ENUM declaration-order sorting, `col + 0` ordinal, out-of-set rejection |
| `22_date_formatting.py` | `TO_CHAR(date/number, fmt)`, `TO_DATE(str, fmt)`, fixed-width padding |

Each example is self-contained (creates/seeds/queries/cleans up its own tables) and ships a deterministic golden verified via `make verify`.

## Notes

- **Example 20** reads `DATETIMETZ`/`DATETIMELTZ` natively but routes `TIMESTAMPTZ` through server-side `TO_CHAR(... TZR)` to sidestep a native-read parsing bug filed as **cubrid-lab/pycubrid#289**. `DATETIMELTZ` native reads come back UTC-aware (`+00:00`); this is documented inline.
- All window/pagination queries carry explicit `ORDER BY` with tie-breakers for determinism; `DENSE_RANK` deliberately omits the tie-breaker to keep a genuine tie visible.

## Development cycle (AGENTS.md)

- **Phase 1 (Oracle design review):** APPROVE-WITH-CHANGES — applied (tie-breakers, `SET TIME ZONE`, `isoformat(timespec="seconds")`, DECIMAL not float, ISO-date normalizer avoidance in ex.22).
- **Phase 4 (Oracle post-impl review):** APPROVE-WITH-CHANGES — applied (ex.17 ranking-tie wording, ex.20 DATETIMELTZ `+00:00` clarification).

## Docs

Updated in the same PR: `fundamentals/pycubrid/README.md` (table rows 17-22), root `README.md` (recipe counts + project structure), `CHANGELOG.md` (`[Unreleased] > Added`).

## Verification

- `make verify VERIFY_PATHS=fundamentals/pycubrid` → 17-22 all PASS (goldens byte-identical across two runs).
- `ruff check` clean; coverage guard + docs-sync clean.
