### PR TITLE
docs: add independence disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ For the ecosystem-wide view, see the [CUBRID Labs Ecosystem Roadmap](https://git
 
 PRs welcome! Each example should be self-contained and independently runnable. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+## Disclaimer
+
+This project is part of [CUBRID Lab](https://github.com/cubrid-lab), an independent open-source initiative for CUBRID developer tooling, and is not affiliated with, sponsored by, or endorsed by CUBRID Corporation or the official CUBRID project.
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
## Summary
Adds a short independence/non-affiliation disclaimer to the README, consistent with the org profile and the other CUBRID Lab repos.

Clarifies that this project is part of the independent [CUBRID Lab](https://github.com/cubrid-lab) initiative and is **not affiliated with, sponsored by, or endorsed by** CUBRID Corporation or the official CUBRID project.

Docs: not needed - this IS a docs-only change (README).